### PR TITLE
Add damper toggle gain and story mask parameters

### DIFF
--- a/parametreler.m
+++ b/parametreler.m
@@ -95,7 +95,9 @@ thermal.dT_max    = 80;              % Maksimum izin verilen ΔT [K]
 
 % Ek kütle/kapasite verileri
 steel_to_oil_mass_ratio = 1.5;       % Çelik/yağ kütle oranı
-n_dampers_per_story    = 1;          % Kat başına damper adedi
+n_dampers_per_story    = 1;          % Kat başına damper adedi (skaler veya (n-1)x1 vektör)
+toggle_gain            = 3.0;        % Toggle kazancı (skaler veya (n-1)x1 vektör)
+story_mask             = ones(n-1,1);% Kat maskesi; 1=aktif, 0=damper yok
 cp_oil   = 1800;                     % Yağın özgül ısısı [J/(kg·K)]
 cp_steel = 500;                      % Çeliğin özgül ısısı [J/(kg·K)]
 resFactor = 3;                       % Hacim/kapasite ölçeği


### PR DESCRIPTION
## Summary
- add `toggle_gain` and `story_mask` damper configuration parameters
- clarify `n_dampers_per_story` comment for scalar or vector use

## Testing
- `octave --version` *(fails: command not found)*
- `sudo dpkg --configure -a` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ac6c10083288c2d2ee2529a056b