### PR TITLE
Set default LaTeX interpreter for plots

### DIFF
--- a/grafik.m
+++ b/grafik.m
@@ -6,6 +6,11 @@
 %    t, x10_0, x10_lin, x10_orf, T1, t5, t95, use_thermal
 %% ================================================================
 
+% Tüm metin öğelerinde LaTeX yorumlayıcısını varsayılan yap
+set(groot,'defaultTextInterpreter','latex');
+set(groot,'defaultLegendInterpreter','latex');
+set(groot,'defaultAxesTickLabelInterpreter','latex');
+
 %% Grafik: 10. kat yer değiştirme eğrileri
 figure('Name','10. Kat yer değiştirme — ham ivme (ODE-only)','Color','w');
 plot(t, x10_0 ,'k','LineWidth',1.4); hold on;


### PR DESCRIPTION
## Summary
- Use LaTeX as the default interpreter for all text, legends and axis ticks in `grafik.m` to eliminate interpreter warnings.

## Testing
- ⚠️ `octave --version` *(missing liblapack.so.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b616b261548328b930677d2bfbb17c