### PR TITLE
Consolidate diagnostics and remove extraneous prints

### DIFF
--- a/1/damperlinon.m
+++ b/1/damperlinon.m
@@ -97,9 +97,6 @@ normM = phi1.' * M * phi1;
 zeta_lin = (phi1.' * C_lin * phi1) / (2*w1*normM);
 zeta_orf = (phi1.' * C_orf * phi1) / (2*w1*normM);
 
-fprintf('Self-check zeta1: %.3f %% (linear) vs %.3f %% (orifice/thermal)\n', ...
-    100*zeta_lin, 100*zeta_orf);
-
 %% 5) Grafiklerin çizimi ve kısa özet
 grafik;
 

--- a/1/grafik.m
+++ b/1/grafik.m
@@ -41,19 +41,4 @@ plot(story_ids, IDR_orf,'r-d','LineWidth',1.0);
 grid on; xlabel('Kat'); ylabel('Maks IDR [Delta x/h]');
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
 
-%% Kısa özet metni
-fprintf('x10_max  (dampersiz)   = %.4g m\n', max(abs(x10_0)));
-fprintf('x10_max  (lineer)      = %.4g m\n', max(abs(x10_lin)));
-if exist('diag_lin','var') && isstruct(diag_lin)
-    fprintf('Lineer diag: c_lam(final)=%.3e N·s/m\n', diag_lin.c_lam);
-end
-if use_thermal
-    suffix = '+termal';
-else
-    suffix = '';
-end
-fprintf('x10_max  (orifisli%s)  = %.4g m\n', suffix, max(abs(x10_orf)));
-if exist('diag_orf','var') && isstruct(diag_orf) && isfield(diag_orf,'dT_est')
-    fprintf('Termal döngü: ΔT_est=%.2f K | c_lam(final)=%.3e N·s/m\n', diag_orf.dT_est, diag_orf.c_lam);
-end
-fprintf('Not: orifis modelini kapatmak için use_orifice=false; termali kapatmak için use_thermal=false.\n');
+%% Kısa özet metni (ekrana yazdırma kaldırıldı)

--- a/2/damperlinon.m
+++ b/2/damperlinon.m
@@ -107,9 +107,6 @@ normM = phi1.' * M * phi1;
 zeta_lin = (phi1.' * C_lin * phi1) / (2*w1*normM);
 zeta_orf = (phi1.' * C_orf * phi1) / (2*w1*normM);
 
-fprintf('Self-check zeta1: %.3f %% (linear) vs %.3f %% (orifice/thermal)\n', ...
-    100*zeta_lin, 100*zeta_orf);
-
 %% 5) Grafiklerin çizimi ve kısa özet
 grafik;
 

--- a/2/grafik.m
+++ b/2/grafik.m
@@ -41,19 +41,4 @@ plot(story_ids, IDR_orf,'r-d','LineWidth',1.0);
 grid on; xlabel('Kat'); ylabel('Maks IDR [Delta x/h]');
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
 
-%% Kısa özet metni
-fprintf('x10_max  (dampersiz)   = %.4g m\n', max(abs(x10_0)));
-fprintf('x10_max  (lineer)      = %.4g m\n', max(abs(x10_lin)));
-if exist('diag_lin','var') && isstruct(diag_lin)
-    fprintf('Lineer diag: c_lam(final)=%.3e N·s/m\n', diag_lin.c_lam);
-end
-if use_thermal
-    suffix = '+termal';
-else
-    suffix = '';
-end
-fprintf('x10_max  (orifisli%s)  = %.4g m\n', suffix, max(abs(x10_orf)));
-if exist('diag_orf','var') && isstruct(diag_orf) && isfield(diag_orf,'dT_est')
-    fprintf('Termal döngü: ΔT_est=%.2f K | c_lam(final)=%.3e N·s/m\n', diag_orf.dT_est, diag_orf.c_lam);
-end
-fprintf('Not: orifis modelini kapatmak için use_orifice=false; termali kapatmak için use_thermal=false.\n');
+%% Kısa özet metni (ekrana yazdırma kaldırıldı)


### PR DESCRIPTION
## Summary
- remove on-screen summaries from grafik and damperlinon scripts
- add linear MCK solver and consolidated diagnostic output
- report zeta1, displacement, and acceleration maxima from diagnostic script

## Testing
- ⚠️ `octave -qf 2/diagnostic.m` *(fails: nested functions not implemented in this context)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e47be1083289bc4be78979844db