### PR TITLE
Add looped multi-record runner with preprocessing and metadata

### DIFF
--- a/2/grafik.m
+++ b/2/grafik.m
@@ -6,7 +6,7 @@
 %    t, x10_0, x10_lin, x10_orf, T1, t5, t95, use_thermal
 
 %% Grafik: 10. kat yer değiştirme eğrileri
-figure('Name','10. Kat yer değiştirme — ham ivme (ODE-only)','Color','w');
+figure('Name',sprintf('10. Kat yer değiştirme — %s', rec_name),'Color','w');
 plot(t, x10_0 ,'k','LineWidth',1.4); hold on;
 plot(t, x10_lin,'b','LineWidth',1.1);
 plot(t, x10_orf,'r','LineWidth',1.0);
@@ -17,7 +17,7 @@ title(sprintf('10-Kat | T1=%.3f s | Arias [%.3f, %.3f] s', T1, t5, t95));
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
 
 %% Grafik: 10. kat mutlak ivme
-figure('Name','10. Kat mutlak ivme','Color','w');
+figure('Name',sprintf('10. Kat mutlak ivme — %s', rec_name),'Color','w');
 plot(t, a10_0 ,'k','LineWidth',1.4); hold on;
 plot(t, a10_lin,'b','LineWidth',1.1);
 plot(t, a10_orf,'r','LineWidth',1.0);
@@ -34,7 +34,7 @@ IDR0      = max(abs(drift0))./story_height;
 IDR_lin   = max(abs(drift_lin))./story_height;
 IDR_orf   = max(abs(drift_orf))./story_height;
 story_ids = 1:(n-1);
-figure('Name','Maksimum IDR','Color','w');
+figure('Name',sprintf('Maksimum IDR — %s', rec_name),'Color','w');
 plot(story_ids, IDR0,'k-o','LineWidth',1.4); hold on;
 plot(story_ids, IDR_lin,'b-s','LineWidth',1.1);
 plot(story_ids, IDR_orf,'r-d','LineWidth',1.0);
@@ -50,6 +50,7 @@ x10_max_d    = max(abs(x10_orf));
 a10abs_max_0 = max(abs(a10_0));
 a10abs_max_d = max(abs(a10_orf));
 
+fprintf('\n== Kayıt: %s ==\n', rec_name);
 fprintf('Self-check zeta1: %.3f %% (dampersiz) vs %.3f %% (damperli)\n', 100*zeta0, 100*zeta_d);
 fprintf('x10_max  (dampersiz)   = %.4g m\n', x10_max_0);
 fprintf('x10_max  (damperli)    = %.4g m\n', x10_max_d);


### PR DESCRIPTION
## Summary
- Run seven acceleration records in a single loop with per-record preprocessing, unit checks and metadata capture
- Display record-aware figures and console summaries

## Testing
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68b89db5a4e08328a7c95c391dc7ec0c