### PR TITLE
Implement multi-record ground motion loader

### DIFF
--- a/2/damperlinon.m
+++ b/2/damperlinon.m
@@ -15,15 +15,10 @@ use_orifice = true;     % Orifis modeli aç/kapa
 use_thermal = true;     % Termal döngü (ΔT ve c_lam(T)) aç/kapa
 
 %% 0) Deprem girdisi (ham ivme, m/s^2)
-S  = load('acc_matrix.mat','acc_matrix7');   % gerekirse path'i değiştirin
-t  = S.acc_matrix7(:,1);
-ag = S.acc_matrix7(:,2);
-
-% tekilleştir + eş-adımlı küçük düzeltme
-[t,iu] = unique(t,'stable'); ag = ag(iu);
-dt  = median(diff(t));
-t   = (t(1):dt:t(end)).';
-ag  = interp1(S.acc_matrix7(:,1), S.acc_matrix7(:,2), t, 'linear');
+recs = load_ground_motions();    % tüm kayıtları yükle
+irec = 1;                        % kullanılacak kayıt indeksi
+t    = recs(irec).t;
+ag   = recs(irec).ag;
 
 % (Sadece gösterim) Arias %5–%95 penceresi
 [t5,t95] = arias_win(t,ag,0.05,0.95);

--- a/2/diagnostic.m
+++ b/2/diagnostic.m
@@ -6,13 +6,10 @@
 clear;
 
 % --- Load earthquake acceleration input ---
-S  = load('acc_matrix.mat','acc_matrix7');
-t  = S.acc_matrix7(:,1);
-ag = S.acc_matrix7(:,2);
-[t,iu] = unique(t,'stable'); ag = ag(iu);
-dt = median(diff(t));
-t  = (t(1):dt:t(end)).';
-ag = interp1(S.acc_matrix7(:,1), S.acc_matrix7(:,2), t, 'linear');
+recs = load_ground_motions();
+irec = 1;                       % index of record to use
+t    = recs(irec).t;
+ag   = recs(irec).ag;
 
 % --- Load structural and damper parameters ---
 parametreler;

--- a/2/load_ground_motions.m
+++ b/2/load_ground_motions.m
@@ -1,0 +1,74 @@
+function records = load_ground_motions()
+%LOAD_GROUND_MOTIONS Load and preprocess multiple ground-motion records.
+%   records = LOAD_GROUND_MOTIONS() loads all ground-motion time histories
+%   from <acc_matrix.mat> whose variables follow the pattern acc_matrix1,
+%   acc_matrix2, ... The function performs basic checks and preprocessing
+%   (demean/detrend and a small high-pass filter) and returns a struct array
+%   with time vector, acceleration, and metadata (name, dt, duration,
+%   rough PGA/PGV).
+%
+%   Requirements: Signal Processing Toolbox for BUTTER/FILTFILT. If not
+%   available, preprocessing will fall back to mean removal only.
+%
+%   Output fields for each record:
+%       name     - variable name inside the MAT-file
+%       t, ag    - time vector and acceleration (m/s^2)
+%       dt       - sampling interval (s)
+%       duration - total duration (s)
+%       PGA      - peak ground acceleration (m/s^2)
+%       PGV      - peak ground velocity (m/s)
+
+raw = load('acc_matrix.mat');
+fn  = fieldnames(raw);
+records = struct('name',{},'t',{},'ag',{},'dt',{},'duration',{},'PGA',{},'PGV',{});
+
+hp_cut = 0.05;   % small high-pass corner [Hz]
+
+for k = 1:numel(fn)
+    A = raw.(fn{k});
+    t  = A(:,1);   ag = A(:,2);
+
+    % Ensure monotonic time and uniqueness
+    [t,iu] = unique(t,'stable'); ag = ag(iu);
+    dt = median(diff(t));
+    % Check for uniform sampling
+    assert(max(abs(diff(t) - dt)) < 1e-6, 'Non-uniform sampling interval');
+    t  = (t(1):dt:t(end)).';
+    ag = interp1(A(:,1), A(:,2), t, 'linear');
+
+    % Basic unit check (expecting m/s^2)
+    assert(max(abs(ag)) < 100, 'Acceleration magnitude suggests wrong units');
+
+    % Preprocess: demean/detrend
+    ag = detrend(ag, 0);          % remove mean
+    ag = detrend(ag, 1);          % remove linear trend
+
+    % High-pass filter (~0.05 Hz). Fall back gracefully if toolbox missing.
+    try
+        Fs = 1/dt;
+        Wn = hp_cut / (Fs/2);
+        [b,a] = butter(2, Wn, 'high');
+        ag = filtfilt(b,a,ag);
+    catch
+        % Butter/filtfilt not available; already demeaned/detrended
+    end
+
+    % Metadata
+    duration = t(end) - t(1);
+    v  = cumtrapz(t, ag);  % integrate acceleration
+    PGA = max(abs(ag));
+    PGV = max(abs(v));
+
+    records(end+1) = struct('name', fn{k}, 't', t, 'ag', ag, ...
+                            'dt', dt, 'duration', duration, ...
+                            'PGA', PGA, 'PGV', PGV); %#ok<AGROW>
+end
+
+% Print a quick summary table
+fprintf('Loaded %d ground-motion records:\n', numel(records));
+for k = 1:numel(records)
+    r = records(k);
+    fprintf('%2d) %-12s dt=%6.4f s dur=%6.2f s PGA=%7.3f PGV=%7.3f\n', ...
+        k, r.name, r.dt, r.duration, r.PGA, r.PGV);
+end
+end


### PR DESCRIPTION
## Summary
- add `load_ground_motions` to load seven time–acceleration records, verify monotonic time and dt, and preprocess with detrend and small high-pass filter
- integrate loader into `damperlinon` and `diagnostic` for easier record selection

## Testing
- `octave -q --eval "addpath('2'); recs = load_ground_motions(); disp(length(recs));"`
- `octave -q --eval "addpath('2'); damperlinon;"` *(fails: parse error near nested functions)*
- `octave -q --eval "addpath('2'); diagnostic;"` *(fails: parse error near nested functions)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b6de182883289796ff80c48aca90