### PR TITLE
Implement spectral-acceleration scaling for ground motions

### DIFF
--- a/2/calc_psa.m
+++ b/2/calc_psa.m
@@ -1,0 +1,38 @@
+function Sa = calc_psa(t, ag, T, zeta)
+%CALC_PSA Compute pseudo spectral acceleration for a single record.
+%   Sa = CALC_PSA(t, ag, T, zeta) returns the peak absolute acceleration
+%   response (pseudo spectral acceleration) of a linear single-degree-of-
+%   freedom oscillator with period T and damping ratio zeta when subjected
+%   to ground acceleration ag defined at times t.
+%
+%   t    - time vector [s]
+%   ag   - ground acceleration vector [m/s^2]
+%   T    - oscillator natural period [s]
+%   zeta - damping ratio (e.g., 0.05 for 5%%)
+%
+%   The equation of motion solved is:
+%       x'' + 2*zeta*w*x' + w^2*x = -ag(t)
+%   where w = 2*pi/T. The absolute acceleration response is x'' + ag.
+%
+%   Note: Requires base functions (no special toolboxes).
+
+w = 2*pi / T;
+% Interpolant for ground acceleration
+agf = griddedInterpolant(t, ag, 'linear', 'nearest');
+
+% ODE state: [x; xdot]
+odef = @(tt, y)[ y(2);
+                 -2*zeta*w*y(2) - w*w*y(1) - agf(tt) ];
+
+% Integrate using ODE45 at specified time points
+y0 = [0; 0];
+[~, y] = ode45(odef, t, y0);
+
+x = y(:,1);            % relative displacement
+xd = y(:,2);           % relative velocity
+% Relative acceleration from equation of motion
+xdd = -2*zeta*w*xd - w*w*x - ag;
+% Absolute acceleration
+abs_acc = xdd + ag;
+Sa = max(abs(abs_acc));
+end

--- a/2/damperlinon.m
+++ b/2/damperlinon.m
@@ -14,18 +14,18 @@ clear; clc; close all;
 use_orifice = true;     % Orifis modeli aç/kapa
 use_thermal = true;     % Termal döngü (ΔT ve c_lam(T)) aç/kapa
 
+%% 1–3) Parametrelerin yüklenmesi
+% Yapı, damper ve akış/termal parametreleri ayrı bir dosyada tutulur.
+parametreler;           % T1 değeri burada hesaplanır
+
 %% 0) Deprem girdisi (ham ivme, m/s^2)
-recs = load_ground_motions();    % tüm kayıtları yükle
+[recs_raw, recs] = load_ground_motions(T1);    % kayıtları yükle ve ölçekle
 irec = 1;                        % kullanılacak kayıt indeksi
 t    = recs(irec).t;
 ag   = recs(irec).ag;
 
 % (Sadece gösterim) Arias %5–%95 penceresi
 [t5,t95] = arias_win(t,ag,0.05,0.95);
-
-%% 1–3) Parametrelerin yüklenmesi
-% Yapı, damper ve akış/termal parametreleri ayrı bir dosyada tutulur.
-parametreler;
 
 %% 4) Çözümler
 [x0,a0]    = lin_MCK(t,ag,M,C0,K);  % dampersiz


### PR DESCRIPTION
## Summary
- Add `calc_psa` utility to evaluate pseudo spectral acceleration for a given period and damping ratio
- Extend `load_ground_motions` to compute PSA-based intensity measures and scale records to a target value
- Update main analysis script to load parameters first and use scaled ground motions alongside raw data

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('hi')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8be3692108328960357a4728a6f02