### PR TITLE
Add Arias window and windowed metric utilities

### DIFF
--- a/arias_win.m
+++ b/arias_win.m
@@ -1,0 +1,32 @@
+﻿function [t5,t95] = arias_win(t,ag,p1,p2)
+    if nargin<3 || isempty(p1), p1=0.05; end
+    if nargin<4 || isempty(p2), p2=0.95; end
+    t=t(:); ag=ag(:);
+    mask=isfinite(t) & isfinite(ag);
+    t=t(mask); ag=ag(mask);
+    if numel(t)<2, t5=t(1); t95=t(end); return; end
+    [t,ia]=unique(t,'stable'); ag=ag(ia);
+    dt=diff(t); a2=ag.^2;
+    Eincr=0.5*(a2(1:end-1)+a2(2:end)).*dt;
+    E=[0; cumsum(Eincr)]; Eend=E(end);
+    if Eend<=eps, t5=t(1); t95=t(end); return; end
+    t5=taf(p1); t95=taf(p2);
+    t5=max(min(t5,t(end)),t(1));
+    t95=max(min(t95,t(end)),t(1));
+    if t95<=t5, t5=t(1); t95=t(end); end
+    function tv=taf(frac)
+        target=frac*Eend;
+        k=find(E>=target,1,'first');
+        if isempty(k)
+            tv=t(end);
+        elseif k==1
+            tv=t(1);
+        else
+            E0=E(k-1); E1=E(k);
+            r=(target-E0)/max(E1-E0,eps);
+            r=min(max(r,0),1);
+            tv=t(k-1)+r*(t(k)-t(k-1));
+        end
+    end
+end
+

--- a/compute_metrics_windowed.m
+++ b/compute_metrics_windowed.m
@@ -1,0 +1,110 @@
+function metr = compute_metrics_windowed(t, x, a_rel, ag, diag, story_height, win)
+%COMPUTE_METRICS_WINDOWED Pencereli metrikleri hesaplar.
+%   Metrikler hem pencere içinde hem de tüm kayıtta hesaplanır.
+%
+%   Girişler:
+%     t, x, a_rel, ag  - zaman ve çözümler
+%     diag             - mck_with_damper çıktısı
+%     story_height     - kat yüksekliği (m)
+%     win              - make_arias_window çıktısı
+%
+%   Çıkış:
+%     metr yapısı: PFA_top, IDR_max, çeşitli akış/enerji/termal metrikler.
+
+idx = win.idx;
+if numel(t) ~= size(x,1)
+    error('Zaman ve çözüm boyutları uyumsuz.');
+end
+
+% PFA üst kat
+if isempty(a_rel)
+    PFA_top = NaN;
+else
+    a_top = a_rel(:,end) + ag(:);
+    PFA_top = max(abs(a_top(idx)));
+end
+
+% IDR maksimumu
+if isempty(x)
+    IDR_max = NaN;
+else
+    drift = diff(x,1,2);
+    IDR_max = max(max(abs(drift(idx,:))))/max(story_height,eps);
+end
+
+metr = struct('PFA_top',PFA_top,'IDR_max',IDR_max);
+
+% --- diag tabanlı metrikler (varsa) ---
+q95 = @(v) prctile(v,95);
+
+fields = {'dP_orf','Q','Qcap_ratio','cav','story_force'};
+for k = 1:numel(fields)
+    f = fields{k};
+    if isfield(diag,f)
+        val = diag.(f);
+        if isvector(val), val = val(:); end
+        metr.([f '_q95']) = q95(abs(val(idx,:)));
+        if strcmp(f,'cav')
+            metr.cav_pct = 100*mean(val(idx,:)<0);
+        end
+    else
+        metr.([f '_q95']) = NaN;
+        if strcmp(f,'cav')
+            metr.cav_pct = NaN;
+        end
+    end
+end
+
+% Enerji
+if isfield(diag,'E_orifice')
+    E_orf_series = diag.E_orifice;
+    E_orifice_full = E_orf_series(end);
+    E_orifice_win  = E_orf_series(find(idx,1,'last')) - E_orf_series(find(idx,1,'first'));
+else
+    E_orifice_win = NaN; E_orifice_full = NaN;
+end
+
+if isfield(diag,'E_struct')
+    E_struct_series = diag.E_struct;
+    E_struct_full = E_struct_series(end);
+    E_struct_win  = E_struct_series(find(idx,1,'last')) - E_struct_series(find(idx,1,'first'));
+else
+    E_struct_win = NaN; E_struct_full = NaN;
+end
+
+E_win = E_orifice_win + E_struct_win;
+E_full = E_orifice_full + E_struct_full;
+E_ratio = E_orifice_full / max(E_struct_full,eps);
+E_cov = E_win / max(E_full,eps);
+
+metr.E_orifice = E_orifice_win;
+metr.E_struct  = E_struct_win;
+metr.E_ratio   = E_ratio;
+metr.E_win_over_full = E_cov;
+
+% Termal
+if isfield(diag,'T_oil')
+    metr.T_oil_end = diag.T_oil(find(idx,1,'last'));
+else
+    metr.T_oil_end = NaN;
+end
+if isfield(diag,'mu')
+    metr.mu_end = diag.mu(find(idx,1,'last'));
+else
+    metr.mu_end = NaN;
+end
+
+% Modal metrikler
+if isfield(diag,'zeta1_hot')
+    metr.zeta1_hot = diag.zeta1_hot;
+else
+    metr.zeta1_hot = NaN;
+end
+if isfield(diag,'zeta2_over_zeta1_hot')
+    metr.z2_over_z1 = diag.zeta2_over_zeta1_hot;
+else
+    metr.z2_over_z1 = NaN;
+end
+
+% Kapsama (E_win/E_full) zaten hesaplandı
+end

--- a/make_arias_window.m
+++ b/make_arias_window.m
@@ -1,0 +1,56 @@
+function win = make_arias_window(t, ag, varargin)
+%MAKE_ARIAS_WINDOW Arias yoğunluk penceresi hesaplar.
+%   win = MAKE_ARIAS_WINDOW(t, ag) varsayılan olarak Arias %5-%95
+%   penceresini ve 0.5 s tamponu kullanır. Ek parametreler
+%   'p1','p2','pad','mode' anahtarları ile geçilebilir.
+%
+%   Çıktı alanları:
+%     t5, t95      - Arias yoğunluğunun %p1 ve %p2 zamanları
+%     pad          - kullanılan tampon (s)
+%     t_start      - pencere başlangıcı
+%     t_end        - pencere sonu
+%     idx          - pencereyi gösteren mantıksal vektör
+%     coverage     - a_g^2 integralinin kapsanan oranı
+%     flag_low_arias - toplam enerji çok düşükse true
+%
+%   Kenar durumları için:
+%     * Eğer kayıt kısa ise (t95-t5 < 5 s) pad=0.25 s yapılır.
+%     * Arias toplamı ~0 ise flag_low_arias=true döner.
+
+p = inputParser;
+p.addParameter('p1',0.05,@(x)isscalar(x)&&x>=0&&x<=1);
+p.addParameter('p2',0.95,@(x)isscalar(x)&&x>=0&&x<=1);
+p.addParameter('pad',0.5,@(x)isscalar(x)&&x>=0);
+p.addParameter('mode','scaled',@(x)ischar(x)||isstring(x));
+p.parse(varargin{:});
+pr = p.Results;
+
+[t5, t95] = arias_win(t, ag, pr.p1, pr.p2);
+pad = pr.pad;
+if t95 - t5 < 5
+    pad = 0.25; % kısa kayıt
+end
+
+% t_start ve t_end hesapla
+if isempty(t)
+    t_start = 0; t_end = 0; idx = false(size(t));
+else
+    t_start = max(t(1), t5 - pad);
+    t_end   = min(t(end), t95 + pad);
+    idx = (t >= t_start) & (t <= t_end);
+end
+
+% kapsama oranı
+E_total = trapz(t, ag.^2);
+if E_total <= eps
+    coverage = 0;
+    flag_low_arias = true;
+else
+    coverage = trapz(t(idx), ag(idx).^2) / E_total;
+    flag_low_arias = (E_total < 1e-4);
+end
+
+win = struct('t5',t5,'t95',t95,'pad',pad,...
+    't_start',t_start,'t_end',t_end,'idx',idx,...
+    'coverage',coverage,'flag_low_arias',flag_low_arias);
+end

--- a/run_batch_windowed.m
+++ b/run_batch_windowed.m
@@ -1,0 +1,83 @@
+function summary = run_batch_windowed(scaled, params, opts)
+%RUN_BATCH_WINDOWED Çoklu kayıtları çalıştırır ve özetler.
+%   summary = RUN_BATCH_WINDOWED(scaled, params, opts)
+%
+%   Dönen summary yapısı:
+%     results      - kayıt bazlı çıktı (run_one_record_windowed)
+%     table        - tablolaştırılmış sonuçlar
+%     max_indices  - [iPFA iIDR]
+%     qc           - basit kalite kontrol bilgileri
+
+if nargin<3, opts = struct(); end
+
+nrec = numel(scaled);
+results(nrec) = struct();
+
+for k = 1:nrec
+    outk = run_one_record_windowed(scaled(k), params, opts);
+    results(k) = outk;
+    % termal reset politikası
+    if isfield(outk.diag,'dT_est')
+        switch opts.thermal_reset
+            case 'carry'
+                params.T0_C = params.T0_C + outk.diag.dT_est;
+            case 'cooldown'
+                hA = params.thermal.hA_W_perK;
+                Cth = 1; % bilinmiyor
+                params.T0_C = params.thermal.T_env_C + (params.T0_C + outk.diag.dT_est - params.thermal.T_env_C) * exp(-hA/Cth * opts.cooldown_s);
+        end
+    end
+    fprintf('[%d/%d] rec="%s"  t5=%.2fs t95=%.2fs cov=%.2f  PFA=%.2f  IDR=%.4f\n', ...
+        k,nrec,outk.name,outk.win.t5,outk.win.t95,outk.win.coverage,outk.metr.PFA_top,outk.metr.IDR_max);
+end
+
+PFA_vals = arrayfun(@(s) s.metr.PFA_top, results);
+IDR_vals = arrayfun(@(s) s.metr.IDR_max, results);
+[~,iPFA] = max(PFA_vals);
+[~,iIDR] = max(IDR_vals);
+
+summary.results = results;
+summary.max_indices = struct('PFA',iPFA,'IDR',iIDR);
+
+% coverage istatistikleri
+covs = arrayfun(@(s) s.win.coverage, results);
+summary.coverage_mean = mean(covs);
+summary.coverage_min  = min(covs);
+
+% tablo
+names = {results.name}.'; scale = [results.scale].'; SaT1 = [results.SaT1].';
+t5 = arrayfun(@(s) s.win.t5, results).';
+t95= arrayfun(@(s) s.win.t95, results).';
+PFA= PFA_vals.'; IDR= IDR_vals.';
+dP95 = arrayfun(@(s) getfield_def(s.metr,'dP_orf_q95',NaN), results).';
+Qcap95 = arrayfun(@(s) getfield_def(s.metr,'Qcap_ratio_q95',NaN), results).';
+cav = arrayfun(@(s) getfield_def(s.metr,'cav_pct',NaN), results).';
+T_end = arrayfun(@(s) getfield_def(s.metr,'T_oil_end',NaN), results).';
+mu_end= arrayfun(@(s) getfield_def(s.metr,'mu_end',NaN), results).';
+E_orf= arrayfun(@(s) getfield_def(s.metr,'E_orifice',NaN), results).';
+E_str= arrayfun(@(s) getfield_def(s.metr,'E_struct',NaN), results).';
+E_ratio= arrayfun(@(s) getfield_def(s.metr,'E_ratio',NaN), results).';
+z1 = arrayfun(@(s) getfield_def(s.metr,'zeta1_hot',NaN), results).';
+z21= arrayfun(@(s) getfield_def(s.metr,'z2_over_z1',NaN), results).';
+coverage=covs.';
+pass_fail = coverage>0.9;
+summary.table = table(names,scale,SaT1,t5,t95,PFA,IDR,dP95,Qcap95,cav,T_end,mu_end,E_orf,E_str,E_ratio,z1,z21,coverage,pass_fail);
+
+% QC
+qc = struct();
+qc.Qcap95 = all(Qcap95<0.5 | isnan(Qcap95));
+qc.cav = all(cav==0 | isnan(cav));
+qc.dP = all(dP95<5e7 | isnan(dP95));
+qc.T_end = all(T_end<=75 | isnan(T_end));
+qc.mu_end = all(mu_end>=0.5 | isnan(mu_end));
+summary.qc = qc;
+
+fprintf('Worst PFA: %s (%.2f m/s^2) | Worst IDR: %s (%.4f)\n', ...
+    results(iPFA).name, results(iPFA).metr.PFA_top, ...
+    results(iIDR).name, results(iIDR).metr.IDR_max);
+fprintf('Coverage mean=%.2f min=%.2f\n', summary.coverage_mean, summary.coverage_min);
+end
+
+function v = getfield_def(s,f,def)
+    if isfield(s,f), v = s.(f); else, v = def; end
+end

--- a/run_one_record_windowed.m
+++ b/run_one_record_windowed.m
@@ -1,0 +1,89 @@
+function out = run_one_record_windowed(rec, params, opts)
+%RUN_ONE_RECORD_WINDOWED Tek deprem kaydını çalıştırır (pencereli).
+%   rec    : scaled(k) elemanı (t, ag, name, scale, IM)
+%   params : parametreler.m çıktıları (M,K,C0, ...)
+%   opts   : yapı (window, sim, thermal_reset, ...)
+%
+%   out alanları: name, scale, SaT1, win, metr, metr0, diag, flags,
+%   which_peak.
+
+if nargin<3, opts = struct(); end
+
+% --- Varsayılan seçenekler ---
+default.window.mode = 'scaled';
+default.window.pad  = 0.5;
+default.sim.mode    = 'full';
+default.thermal_reset = 'each';
+default.cooldown_s    = 0;
+opts = merge_struct(default, opts);
+
+% 1) Arias penceresi
+win = make_arias_window(rec.t, rec.ag, 'pad', opts.window.pad, 'mode', opts.window.mode);
+
+% 2) Dampersiz çözüm
+[x0, a_rel0] = lin_MCK(rec.t, rec.ag, params.M, params.C0, params.K);
+metr0.PFA_top = max(abs(a_rel0(win.idx,end) + rec.ag(win.idx)));
+drift0 = diff(x0,1,2);
+metr0.IDR_max = max(max(abs(drift0(win.idx,:))))/params.story_height;
+
+% 3) Damperli çözüm
+use_orf = getfield(params,'use_orifice',true);
+use_thermal = getfield(params,'use_thermal',true);
+[x, a_rel, diag] = mck_with_damper(rec.t, rec.ag, params.M, params.C0, params.K, ...
+    params.k_sd, params.c_lam0, use_orf, params.orf, params.rho, params.Ap, params.A_o, params.Qcap_big, params.mu_ref, ...
+    use_thermal, params.thermal, params.T0_C, params.T_ref_C, params.b_mu, params.c_lam_min, params.c_lam_cap, params.Lgap, ...
+    params.cp_oil, params.cp_steel, params.steel_to_oil_mass_ratio, params.toggle_gain, params.story_mask, ...
+    params.n_dampers_per_story, params.resFactor, params.cfg);
+
+% 4) Metrikler
+metr = compute_metrics_windowed(rec.t, x, a_rel, rec.ag, diag, params.story_height, win);
+
+% 5) Hangi zamanda tepe?
+t_win = rec.t(win.idx);
+[~,k_pfa] = max(abs(a_rel(win.idx,end) + rec.ag(win.idx)));
+which_peak.PFA.time = t_win(k_pfa);
+which_peak.PFA.value = metr.PFA_top;
+
+% IDR tepe
+if ~isempty(x)
+    drift = diff(x(win.idx,:),1,2);
+    [mx,idxmx] = max(abs(drift(:)));
+    [row,col] = ind2sub(size(drift),idxmx);
+    which_peak.IDR.time  = t_win(row);
+    which_peak.IDR.story = col;
+    which_peak.IDR.value = mx/params.story_height;
+else
+    which_peak.IDR = struct('time',NaN,'story',NaN,'value',NaN);
+end
+
+% 6) Tutarlılık kontrolü (a_abs ≈ a_rel + ag)
+if ~isempty(x)
+    r = randi(numel(t_win));
+    idx_glob = find(win.idx);
+    k = idx_glob(r);
+    dt = mean(diff(rec.t));
+    v_top = gradient(x(:,end), dt);
+    a_from_x = gradient(v_top, dt);
+    err = abs((a_from_x(k) + rec.ag(k)) - (a_rel(k,end) + rec.ag(k)));
+    if err > 1e-6
+        warning('a_abs kontrolü başarısız: %.3e', err);
+    end
+end
+
+out = struct();
+out.name   = rec.name;
+out.scale  = rec.scale;
+out.SaT1   = rec.IM;
+out.win    = win;
+out.metr   = metr;
+out.metr0  = metr0;
+out.diag   = diag;
+out.flags  = struct('low_arias',win.flag_low_arias);
+out.which_peak = which_peak;
+end
+
+function s = merge_struct(a,b)
+    s = a;
+    f = fieldnames(b);
+    for i=1:numel(f), s.(f{i}) = b.(f{i}); end
+end

--- a/tests/run_tests.m
+++ b/tests/run_tests.m
@@ -1,0 +1,19 @@
+function run_tests
+% Basit doğrulama testleri
+
+% 1. Arias penceresi testi
+Fs = 100; t = (0:1/Fs:10).'; ag = sin(2*pi*1*t);
+win = make_arias_window(t, ag);
+assert(win.coverage > 0.9, 'coverage düşük');
+
+% 2. Metrik hesaplama testi
+x = [0.01*sin(2*pi*1*t), 0.02*sin(2*pi*1*t)];
+a_rel = x;
+diag = struct('E_orifice',cumsum(0.1*ones(size(t))), ...
+              'E_struct',cumsum(0.2*ones(size(t))), ...
+              'T_oil',20+0.1*t, 'mu',0.9*ones(size(t)));
+metr = compute_metrics_windowed(t, x, a_rel, ag, diag, 3.0, win);
+assert(isfield(metr,'PFA_top'));
+
+fprintf('run_tests: tüm testler geçti.\n');
+end


### PR DESCRIPTION
## Summary
- Implement `make_arias_window` to generate Arias intensity based time windows with coverage checks
- Add `compute_metrics_windowed`, `run_one_record_windowed`, and `run_batch_windowed` for windowed metric calculation and batch processing
- Include basic Octave tests for windowing and metric calculations

## Testing
- `octave -qf --path tests --eval "run_tests"`


------
https://chatgpt.com/codex/tasks/task_e_68b8c6dc0df08328a4ff67121dc6dd07