### PR TITLE
Add toggle between scaled and raw ground motions

### DIFF
--- a/2/damperlinon.m
+++ b/2/damperlinon.m
@@ -19,7 +19,13 @@ use_thermal = true;     % Termal döngü (ΔT ve c_lam(T)) aç/kapa
 parametreler;           % T1 değeri burada hesaplanır
 
 %% 0) Deprem girdisi (ham ivme, m/s^2)
-[recs_raw, recs] = load_ground_motions(T1);    % kayıtları yükle ve ölçekle
+use_scaled = true;               % true → ölçekli kayıt, false → ham kayıt
+if use_scaled
+    [recs_raw, recs] = load_ground_motions(T1);   % kayıtları yükle ve ölçekle
+else
+    [recs_raw, ~] = load_ground_motions();        % sadece ham kayıtları yükle
+    recs = recs_raw;
+end
 irec = 1;                        % kullanılacak kayıt indeksi
 t    = recs(irec).t;
 ag   = recs(irec).ag;


### PR DESCRIPTION
## Summary
- Add `use_scaled` switch in `damperlinon.m` to select scaled or raw ground-motion records.

## Testing
- `octave 2/damperlinon.m >/tmp/octave.log && tail -n 20 /tmp/octave.log` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9757111f08328b87f5b30a719473b