### PR TITLE
Add time-series wrapper for damper model

### DIFF
--- a/2/mck_with_damper_ts.m
+++ b/2/mck_with_damper_ts.m
@@ -1,0 +1,55 @@
+function [x,a_rel,ts,diag] = mck_with_damper_ts(t,ag,M,C,K, k_sd,c_lam0, use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, n_dampers_per_story, resFactor, cfg)
+%MCK_WITH_DAMPER_TS Wrapper around MCK_WITH_DAMPER returning time-series.
+%
+%   [X,A_REL,TS,DIAG] = MCK_WITH_DAMPER_TS(T,AG,M,C,K, ...) calls the existing
+%   MCK_WITH_DAMPER function to compute the structural response and then
+%   assembles a time-series structure TS containing various per–time-step
+%   diagnostics such as power and energy histories.  The original diagnostic
+%   structure DIAG is returned unchanged.
+
+% Solve using the existing implementation
+[x,a_rel,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0, use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, ...
+    use_thermal, thermal, T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, ...
+    cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
+    n_dampers_per_story, resFactor, cfg);
+
+% Story vectors needed for power calculations
+nStories = size(diag.drift,2);
+Rvec = toggle_gain(:); if numel(Rvec)==1, Rvec = Rvec*ones(nStories,1); end
+mask = story_mask(:); if numel(mask)==1, mask = mask*ones(nStories,1); end
+ndps = n_dampers_per_story(:); if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
+multi = (mask .* ndps).';
+Rvec = Rvec.';
+
+% Basic time series fields from diagnostics
+ts = struct();
+ts.t = t;
+ts.drift = diag.drift;
+ts.dvel = diag.dvel;
+ts.story_force = diag.story_force;
+ts.Q = diag.Q;
+ts.dP_orf = diag.dP_orf;
+ts.Qcap_ratio = abs(diag.Q) ./ Qcap;
+ts.cav_mask = diag.dP_orf < 0;
+
+% Power components
+% Piston velocity for each damper
+
+% dvel at pistons
+ dvel_p = diag.dvel .* Rvec;
+ P_visc_per = diag.c_lam * (dvel_p.^2);
+ ts.P_visc = sum(P_visc_per .* multi, 2);
+
+ P_orf_per = diag.dP_orf .* diag.Q;
+ ts.P_orf = sum(P_orf_per .* multi, 2);
+
+ ts.P_sum = diag.P_sum;
+
+% Energy accumulations
+ P_struct = sum(diag.story_force .* diag.dvel, 2);
+ ts.E_orf = cumtrapz(t, ts.P_orf);
+ ts.E_struct = cumtrapz(t, P_struct);
+ ts.E_mech = cumtrapz(t, ts.P_sum);
+
+% DIAG is returned unchanged
+end


### PR DESCRIPTION
## Summary
- Add `mck_with_damper_ts` which wraps `mck_with_damper` and assembles a comprehensive time-series structure of damper diagnostics
- Compute per-step powers and cumulative energies for orifice, structure, and mechanical dissipation

## Testing
- `octave -qf --eval "which('mck_with_damper_ts')"` *(fails: command not found)*
- `matlab -batch "which('mck_with_damper_ts')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b6e8aa08328a72edbe1b662f5e6