### PR TITLE
Fix energy windowing and defaults in analysis utilities

### DIFF
--- a/2/compute_metrics_windowed.m
+++ b/2/compute_metrics_windowed.m
@@ -53,26 +53,30 @@ metr.Qcap_ratio_q95  = Qcap_ratio_q95(ws);
 metr.cav_pct         = cav_mean(ws);
 
 % ----------------------- Energy calculations -------------------------
-wstart = find(idx,1,'first');
-wend   = find(idx,1,'last');
+w_first = find(idx,1,'first');
+w_last  = find(idx,1,'last');
+i0 = max(w_first-1,1);
 
 metr.E_orifice_full = ts.E_orf(end);
 metr.E_struct_full  = ts.E_struct(end);
 metr.E_ratio_full   = metr.E_orifice_full / max(metr.E_struct_full, eps);
 
-metr.E_orifice_win = ts.E_orf(wend) - ts.E_orf(wstart);
-metr.E_struct_win  = ts.E_struct(wend) - ts.E_struct(wstart);
+metr.E_orifice_win = ts.E_orf(w_last) - ts.E_orf(i0);
+metr.E_struct_win  = ts.E_struct(w_last) - ts.E_struct(i0);
+if isfield(ts,'E_mech')
+    metr.E_mech_win = ts.E_mech(w_last) - ts.E_mech(i0);
+end
 metr.E_ratio_win   = metr.E_orifice_win / max(metr.E_struct_win, eps);
 metr.E_win_over_full = metr.E_orifice_win / max(metr.E_orifice_full, eps);
 
 % -------------------- Thermal/viscosity metrics ----------------------
 if isfield(params,'diag') && isfield(params.diag,'T_oil')
-    metr.T_oil_end = params.diag.T_oil(wend);
+    metr.T_oil_end = params.diag.T_oil(w_last);
 else
     metr.T_oil_end = NaN;
 end
 if isfield(params,'diag') && isfield(params.diag,'mu')
-    metr.mu_end = params.diag.mu(wend);
+    metr.mu_end = params.diag.mu(w_last);
 else
     metr.mu_end = NaN;
 end

--- a/2/mck_with_damper_ts.m
+++ b/2/mck_with_damper_ts.m
@@ -43,13 +43,21 @@ ts.cav_mask = diag.dP_orf < 0;
  P_orf_per = diag.dP_orf .* diag.Q;
  ts.P_orf = sum(P_orf_per .* multi, 2);
 
- ts.P_sum = diag.P_sum;
+if isfield(diag,'P_sum')
+    ts.P_sum = diag.P_sum;
+else
+    if isfield(ts,'P_orf') && isfield(ts,'P_visc')
+        ts.P_sum = ts.P_orf + ts.P_visc;
+    else
+        ts.P_sum = [];
+    end
+end
 
 % Energy accumulations
  P_struct = sum(diag.story_force .* diag.dvel, 2);
  ts.E_orf = cumtrapz(t, ts.P_orf);
  ts.E_struct = cumtrapz(t, P_struct);
- ts.E_mech = cumtrapz(t, ts.P_sum);
+ts.E_mech = cumtrapz(t, ts.P_sum);
 
 % DIAG is returned unchanged
 end

--- a/2/run_batch_windowed.m
+++ b/2/run_batch_windowed.m
@@ -1,9 +1,10 @@
-function summary = run_batch_windowed(scaled, params, opts)
+function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 %RUN_BATCH_WINDOWED Analyse multiple records with windowed metrics.
-%   SUMMARY = RUN_BATCH_WINDOWED(SCALED, PARAMS, OPTS) processes each
-%   groundâmotion record in the struct array SCALED using
-%   RUN_ONE_RECORD_WINDOWED and returns a summary table of key metrics.
-%   PARAMS bundles structural and damper properties. OPTS are forwarded to
+%   [SUMMARY, ALL_OUT] = RUN_BATCH_WINDOWED(SCALED, PARAMS, OPTS) processes each
+%   ground-motion record in the struct array SCALED using
+%   RUN_ONE_RECORD_WINDOWED and returns a summary table of key metrics. The
+%   cell array ALL_OUT contains the full outputs for each record. PARAMS
+%   bundles structural and damper properties. OPTS are forwarded to
 %   RUN_ONE_RECORD_WINDOWED.
 %
 %   QC logs are printed for IM consistency, low Arias coverage, physical

--- a/2/run_one_record_windowed.m
+++ b/2/run_one_record_windowed.m
@@ -27,6 +27,21 @@ if nargin < 4 || isempty(opts), opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
 
+if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
+    if ~isfield(opts,'cooldown_s') || isempty(opts.cooldown_s) || isnan(opts.cooldown_s)
+        opts.cooldown_s = 60;
+    end
+    opts.cooldown_s = max(opts.cooldown_s,0);
+end
+
+assert(numel(opts.mu_factors)==numel(opts.mu_weights), ...
+    'mu_factors and mu_weights must have same length.');
+mu_weights = opts.mu_weights(:);
+wsum = sum(mu_weights);
+assert(wsum>0,'mu_weights sum must be > 0.');
+mu_weights = mu_weights/wsum;
+mu_factors = opts.mu_factors(:)';
+
 %% ----------------------- Arias intensity window ----------------------
 if isfield(opts,'window') && ~isempty(opts.window)
     wfields = fieldnames(opts.window);
@@ -120,8 +135,6 @@ if ~isfield(opts,'store_metr0') || opts.store_metr0
 end
 
 %% ----------------- Damper model with time series ---------------------
-mu_factors = opts.mu_factors(:)';
-mu_weights = opts.mu_weights(:)';
 nMu = numel(mu_factors);
 mu_results = struct('mu_factor',cell(1,nMu));
 


### PR DESCRIPTION
## Summary
- correct windowed energy calculations to avoid double-counting initial sample
- sanitize cooldown duration and normalize viscosity weights for robustness
- guard combined power output when diagnostic field is absent
- expose per-record outputs from batch runner

## Testing
- `octave --version`
- `octave -qf --eval "which compute_metrics_windowed"`


------
https://chatgpt.com/codex/tasks/task_e_68b9cec0edfc8328a008d1822001dbb3