### PR TITLE
Add thermal reset policy orchestration and logging

### DIFF
--- a/2/compute_metrics_windowed.m
+++ b/2/compute_metrics_windowed.m
@@ -53,26 +53,30 @@ metr.Qcap_ratio_q95  = Qcap_ratio_q95(ws);
 metr.cav_pct         = cav_mean(ws);
 
 % ----------------------- Energy calculations -------------------------
-wstart = find(idx,1,'first');
-wend   = find(idx,1,'last');
+w_first = find(idx,1,'first');
+w_last  = find(idx,1,'last');
+i0 = max(w_first-1,1);
 
 metr.E_orifice_full = ts.E_orf(end);
 metr.E_struct_full  = ts.E_struct(end);
 metr.E_ratio_full   = metr.E_orifice_full / max(metr.E_struct_full, eps);
 
-metr.E_orifice_win = ts.E_orf(wend) - ts.E_orf(wstart);
-metr.E_struct_win  = ts.E_struct(wend) - ts.E_struct(wstart);
+metr.E_orifice_win = ts.E_orf(w_last) - ts.E_orf(i0);
+metr.E_struct_win  = ts.E_struct(w_last) - ts.E_struct(i0);
+if isfield(ts,'E_mech')
+    metr.E_mech_win = ts.E_mech(w_last) - ts.E_mech(i0);
+end
 metr.E_ratio_win   = metr.E_orifice_win / max(metr.E_struct_win, eps);
 metr.E_win_over_full = metr.E_orifice_win / max(metr.E_orifice_full, eps);
 
 % -------------------- Thermal/viscosity metrics ----------------------
 if isfield(params,'diag') && isfield(params.diag,'T_oil')
-    metr.T_oil_end = params.diag.T_oil(wend);
+    metr.T_oil_end = params.diag.T_oil(w_last);
 else
     metr.T_oil_end = NaN;
 end
 if isfield(params,'diag') && isfield(params.diag,'mu')
-    metr.mu_end = params.diag.mu(wend);
+    metr.mu_end = params.diag.mu(w_last);
 else
     metr.mu_end = NaN;
 end

--- a/2/mck_with_damper_ts.m
+++ b/2/mck_with_damper_ts.m
@@ -43,13 +43,21 @@ ts.cav_mask = diag.dP_orf < 0;
  P_orf_per = diag.dP_orf .* diag.Q;
  ts.P_orf = sum(P_orf_per .* multi, 2);
 
- ts.P_sum = diag.P_sum;
+if isfield(diag,'P_sum')
+    ts.P_sum = diag.P_sum;
+else
+    if isfield(ts,'P_orf') && isfield(ts,'P_visc')
+        ts.P_sum = ts.P_orf + ts.P_visc;
+    else
+        ts.P_sum = [];
+    end
+end
 
 % Energy accumulations
  P_struct = sum(diag.story_force .* diag.dvel, 2);
  ts.E_orf = cumtrapz(t, ts.P_orf);
  ts.E_struct = cumtrapz(t, P_struct);
- ts.E_mech = cumtrapz(t, ts.P_sum);
+ts.E_mech = cumtrapz(t, ts.P_sum);
 
 % DIAG is returned unchanged
 end

--- a/2/run_batch_windowed.m
+++ b/2/run_batch_windowed.m
@@ -1,9 +1,10 @@
-function summary = run_batch_windowed(scaled, params, opts)
+function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 %RUN_BATCH_WINDOWED Analyse multiple records with windowed metrics.
-%   SUMMARY = RUN_BATCH_WINDOWED(SCALED, PARAMS, OPTS) processes each
-%   groundâmotion record in the struct array SCALED using
-%   RUN_ONE_RECORD_WINDOWED and returns a summary table of key metrics.
-%   PARAMS bundles structural and damper properties. OPTS are forwarded to
+%   [SUMMARY, ALL_OUT] = RUN_BATCH_WINDOWED(SCALED, PARAMS, OPTS) processes each
+%   ground-motion record in the struct array SCALED using
+%   RUN_ONE_RECORD_WINDOWED and returns a summary table of key metrics. The
+%   cell array ALL_OUT contains the full outputs for each record. PARAMS
+%   bundles structural and damper properties. OPTS are forwarded to
 %   RUN_ONE_RECORD_WINDOWED.
 %
 %   QC logs are printed for IM consistency, low Arias coverage, physical
@@ -26,6 +27,16 @@ t5       = zeros(n,1);
 t95      = zeros(n,1);
 coverage = zeros(n,1);
 
+% policy/order info
+policy_col   = repmat({getfield(opts,'thermal_reset','each')}, n,1);
+order_col    = repmat({getfield(opts,'order','natural')}, n,1);
+if isfield(opts,'cooldown_s')
+    cooldown_val = opts.cooldown_s;
+else
+    cooldown_val = NaN;
+end
+cooldown_col = repmat(cooldown_val, n,1);
+
 PFA_nom    = zeros(n,1);
 IDR_nom    = zeros(n,1);
 dP95_nom   = zeros(n,1);
@@ -47,6 +58,11 @@ T_end_worst  = zeros(n,1);
 mu_end_worst = zeros(n,1);
 qc_all_mu    = false(n,1);
 
+T_start    = zeros(n,1);
+T_end      = zeros(n,1);
+mu_end     = zeros(n,1);
+clamp_hits = zeros(n,1);
+
 worstPFA = -inf; worstPFA_name = ''; worstPFA_mu = NaN;
 worstIDR = -inf; worstIDR_name = ''; worstIDR_mu = NaN;
 
@@ -63,6 +79,11 @@ for k = 1:n
     t5(k)       = out.win.t5;
     t95(k)      = out.win.t95;
     coverage(k) = out.win.coverage;
+
+    T_start(k)    = out.T_start;
+    T_end(k)      = out.T_end;
+    mu_end(k)     = out.mu_end;
+    clamp_hits(k) = out.clamp_hits;
 
     m_nom = out.metr;
     PFA_nom(k)    = m_nom.PFA_top;
@@ -105,16 +126,18 @@ for k = 1:n
 end
 
 summary = struct();
-summary.table = table(names, scale, SaT1, t5, t95, coverage, ...
+summary.table = table(names, scale, SaT1, t5, t95, coverage, policy_col, order_col, cooldown_col, ...
     PFA_nom, IDR_nom, dP95_nom, Qcap95_nom, cav_nom, ...
     PFA_w, IDR_w, dP95_w, Qcap95_w, ...
     PFA_worst, IDR_worst, dP95_worst, Qcap95_worst, ...
     which_mu_PFA, which_mu_IDR, T_end_worst, mu_end_worst, qc_all_mu, ...
-    'VariableNames', {'name','scale','SaT1','t5','t95','coverage', ...
+    T_start, T_end, mu_end, clamp_hits, ...
+    'VariableNames', {'name','scale','SaT1','t5','t95','coverage','policy','order','cooldown_s', ...
     'PFA_nom','IDR_nom','dP95_nom','Qcap95_nom','cav_nom', ...
     'PFA_w','IDR_w','dP95_w','Qcap95_w', ...
     'PFA_worst','IDR_worst','dP95_worst','Qcap95_worst', ...
-    'which_mu_PFA','which_mu_IDR','T_end_worst','mu_end_worst','qc_all_mu'});
+    'which_mu_PFA','which_mu_IDR','T_end_worst','mu_end_worst','qc_all_mu', ...
+    'T_start','T_end','mu_end','clamp_hits'});
 summary.all_out = all_out;
 
 fprintf('Worst PFA: %s, mu=%.2f\n', worstPFA_name, worstPFA_mu);

--- a/2/run_policies_windowed.m
+++ b/2/run_policies_windowed.m
@@ -1,0 +1,99 @@
+function P = run_policies_windowed(scaled, params, opts)
+%RUN_POLICIES_WINDOWED Evaluate thermal reset policies and record orders.
+%   P = RUN_POLICIES_WINDOWED(SCALED, PARAMS, OPTS) orchestrates calls to
+%   RUN_BATCH_WINDOWED for combinations of thermal reset policies and record
+%   processing orders.  OPTS.policies selects a subset of {'each','carry',
+%   'cooldown'} and OPTS.orders selects from {'natural','random','worst_first'}.
+%   When 'cooldown' is included, OPTS.cooldown_s_list specifies the cooldown
+%   durations to test.  The resulting struct array P contains, for each
+%   combination, the policy, order, cooldown duration, summary table, QC stats
+%   and deviations relative to the baseline each/natural run.
+%
+%   OPTS.mu_factors and OPTS.mu_weights mirror RUN_BATCH_WINDOWED defaults.
+%   OPTS.rng_seed controls reproducibility of the 'random' order.
+%
+%   Example:
+%       opts.policies = {'each','carry','cooldown'};
+%       opts.orders   = {'natural','worst_first'};
+%       opts.cooldown_s_list = [60 180 300];
+%       P = run_policies_windowed(scaled, params, opts);
+%
+%   See RUN_BATCH_WINDOWED for additional options.
+
+if nargin < 3, opts = struct(); end
+if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
+if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
+if ~isfield(opts,'policies'), opts.policies = {'each','carry','cooldown'}; end
+if ~isfield(opts,'orders'), opts.orders = {'natural','random','worst_first'}; end
+if ~isfield(opts,'cooldown_s_list'), opts.cooldown_s_list = 60; end
+if ~isfield(opts,'rng_seed'), opts.rng_seed = 42; end
+
+nRec = numel(scaled);
+
+% Baseline run for deltas and worst_first ordering
+base_opts = opts; base_opts.thermal_reset = 'each'; base_opts.order = 'natural';
+[base_summary, base_all] = run_batch_windowed(scaled, params, base_opts);
+basePFA = max(base_summary.table.PFA_nom);
+baseIDR = max(base_summary.table.IDR_nom);
+baseTend = max(base_summary.table.T_end);
+
+% Pre-compute orders
+orders_struct.natural = 1:nRec;
+if any(strcmp(opts.orders,'random'))
+    rng(opts.rng_seed);
+    orders_struct.random = randperm(nRec);
+end
+if any(strcmp(opts.orders,'worst_first'))
+    E = cellfun(@(s) s.metr.E_orifice_win, base_all);
+    [~,idx] = sort(E,'descend');
+    orders_struct.worst_first = idx;
+end
+
+% Iterate combinations
+P = struct('policy',{},'order',{},'cooldown_s',{},'summary',{},'qc',{},'deltas',{});
+for ip = 1:numel(opts.policies)
+    pol = opts.policies{ip};
+    for io = 1:numel(opts.orders)
+        ord = opts.orders{io};
+        if strcmp(pol,'cooldown')
+            cds = opts.cooldown_s_list(:)';
+        else
+            cds = NaN;
+        end
+        for ic = 1:numel(cds)
+            cdval = cds(ic);
+            perm = orders_struct.(ord);
+            scaled_run = scaled(perm);
+            run_opts = opts;
+            if isfield(run_opts,'cooldown_s'), run_opts = rmfield(run_opts,'cooldown_s'); end
+            run_opts.order = ord;
+            run_opts.thermal_reset = pol;
+            if strcmp(pol,'cooldown'), run_opts.cooldown_s = cdval; end
+            [summary, ~] = run_batch_windowed(scaled_run, params, run_opts);
+
+            qc.pass_fraction = mean(summary.table.qc_all_mu);
+            qc.n = height(summary.table);
+
+            curPFA = max(summary.table.PFA_nom);
+            curIDR = max(summary.table.IDR_nom);
+            curTend = max(summary.table.T_end);
+            deltas = struct('PFA', curPFA - basePFA, ...
+                            'IDR', curIDR - baseIDR, ...
+                            'T_end', curTend - baseTend);
+
+            % log worst cases
+            [worstPFA, idxP] = max(summary.table.PFA_worst);
+            nP = summary.table.name{idxP};
+            muP = summary.table.which_mu_PFA(idxP);
+            fprintf('Worst PFA (%s,%s,mu=%.2f): %s\n', pol, ord, muP, nP);
+            [worstIDR, idxI] = max(summary.table.IDR_worst); %#ok<NASGU>
+            nI = summary.table.name{idxI};
+            muI = summary.table.which_mu_IDR(idxI);
+            fprintf('Worst IDR (%s,%s,mu=%.2f): %s\n', pol, ord, muI, nI);
+
+            P(end+1) = struct('policy',pol,'order',ord,'cooldown_s',cdval, ...
+                'summary',summary.table,'qc',qc,'deltas',deltas); %#ok<AGROW>
+        end
+    end
+end
+end


### PR DESCRIPTION
## Summary
- capture start/end thermal state per record and count temperature clamp hits
- include policy, order, cooldown, and thermal metrics in batch summaries
- add orchestrator to evaluate multiple thermal reset policies and orderings

## Testing
- `octave --version` *(fails: command not found)*
- `octave -qf --eval "which run_policies_windowed"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b9cec0edfc8328a008d1822001dbb3