### PR TITLE
Add export utilities for simulation outputs

### DIFF
--- a/2/downsample_ts.m
+++ b/2/downsample_ts.m
@@ -1,0 +1,16 @@
+function ts_ds = downsample_ts(ts, ds)
+%DOWNSAMPLE_TS Downsample all numeric fields in a struct.
+%   TS_DS = DOWNSAMPLE_TS(TS, DS) keeps every DS-th row of numeric array fields.
+if nargin < 2 || isempty(ds), ds = 5; end
+fns = fieldnames(ts);
+ts_ds = struct();
+for i = 1:numel(fns)
+    val = ts.(fns{i});
+    if isnumeric(val) && ~isscalar(val)
+        idx = 1:ds:size(val,1);
+        ts_ds.(fns{i}) = val(idx,:,:);
+    else
+        ts_ds.(fns{i}) = val;
+    end
+end
+end

--- a/2/export_results.m
+++ b/2/export_results.m
@@ -1,0 +1,140 @@
+function export_results(outdir, scaled, params, opts, summary, all_out, varargin)
+%EXPORT_RESULTS Persist results to out/<timestamp>/ directory.
+%   EXPORT_RESULTS(OUTDIR, SCALED, PARAMS, OPTS, SUMMARY, ALL_OUT)
+%   writes various logs and per-record details.  Optional additional
+%   structures (e.g., policy results) may be passed in VARARGIN.
+
+if nargin < 1 || isempty(outdir), return; end
+if ~exist(outdir,'dir'), mkdir(outdir); end
+
+%% Meta/snapshot
+try
+    save(fullfile(outdir,'snapshot.mat'), 'params','opts','scaled','-v7.3');
+catch
+end
+try
+    names = {scaled.name}';
+    dt = arrayfun(@(s) getfield(s,'dt',NaN), scaled)'; %#ok<GFLD>
+    dur = arrayfun(@(s) getfield(s,'duration',NaN), scaled)'; %#ok<GFLD>
+    PGA = arrayfun(@(s) getfield(s,'PGA',NaN), scaled)'; %#ok<GFLD>
+    PGV = arrayfun(@(s) getfield(s,'PGV',NaN), scaled)'; %#ok<GFLD>
+    IM  = arrayfun(@(s) getfield(s,'IM',NaN), scaled)'; %#ok<GFLD>
+    sc  = arrayfun(@(s) getfield(s,'scale',NaN), scaled)'; %#ok<GFLD>
+    tbl = table(names, dt, dur, PGA, PGV, IM, sc, ...
+        'VariableNames',{'name','dt','dur','PGA','PGV','IM','scale'});
+    writetable(tbl, fullfile(outdir,'scaled_index.csv'));
+catch
+end
+
+%% Summaries
+try
+    writetable(summary.table, fullfile(outdir,'summary.csv'));
+catch
+end
+try
+    save(fullfile(outdir,'summary_full.mat'), 'summary','all_out','-v7.3');
+catch
+end
+try
+    pass = sum(summary.table.qc_all_mu);
+    fail = height(summary.table) - pass;
+    [~,idx] = maxk(summary.table.PFA_worst, min(3,height(summary.table)));
+    worst = summary.table.name(idx);
+    qc_tbl = table(pass, fail, worst, 'VariableNames',{'pass','fail','worst'});
+    writetable(qc_tbl, fullfile(outdir,'qc_summary.csv'));
+catch
+end
+
+%% Record-based details
+for k = 1:numel(all_out)
+    out = all_out{k};
+    try
+        recdir = fullfile(outdir, ['rec-' sanitize_name(out.name)]);
+        if ~exist(recdir,'dir'), mkdir(recdir); end
+        % window.json
+        try
+            w = out.win;
+            win_struct = struct('t5',w.t5,'t95',w.t95,'pad',getfield(w,'pad',0), ...
+                                'coverage',w.coverage);
+            writejson(win_struct, fullfile(recdir,'window.json'));
+        catch
+        end
+        % mu_results.csv
+        if isfield(out,'mu_results') && ~isempty(out.mu_results)
+            try
+                mu_tbl = struct2table(arrayfun(@(s) s.metr, out.mu_results));
+                mu_tbl.mu = [out.mu_results.mu_factor]';
+                mu_tbl = movevars(mu_tbl,'mu','before',1);
+                writetable(mu_tbl, fullfile(recdir,'mu_results.csv'));
+            catch
+            end
+        end
+        % metrics_win.csv
+        try
+            m = out.metr;
+            mstruct = struct('PFA_top',m.PFA_top,'IDR_max',m.IDR_max, ...
+                             'dP95',m.dP_orf_q95,'Qcap95',m.Qcap_ratio_q95, ...
+                             'cav_pct',m.cav_pct,'T_end',out.T_end,'mu_end',out.mu_end);
+            if isfield(m,'E_orifice_win'), mstruct.E_orf_win = m.E_orifice_win; end
+            if isfield(m,'E_struct_win'), mstruct.E_struct_win = m.E_struct_win; end
+            metr_tbl = struct2table(mstruct);
+            writetable(metr_tbl, fullfile(recdir,'metrics_win.csv'));
+        catch
+        end
+        % ts_ds.mat
+        if isfield(out,'ts') && ~isempty(out.ts)
+            try
+                ds = 5;
+                if isfield(opts,'export') && isfield(opts.export,'ds')
+                    ds = opts.export.ds;
+                end
+                ts_ds = downsample_ts(out.ts, ds);
+                save(fullfile(recdir,'ts_ds.mat'),'ts_ds','-v7.3');
+            catch
+            end
+        end
+        % optional plots
+        if isfield(opts,'export') && isfield(opts.export,'plots') && opts.export.plots
+            try
+                figdir = fullfile(recdir,'figures');
+                if ~exist(figdir,'dir'), mkdir(figdir); end
+                f = figure('Visible','off');
+                bar(out.metr.IDR_max); title('IDR_{max}');
+                saveas(f, fullfile(figdir,'IDR_max.png')); close(f);
+                f = figure('Visible','off');
+                bar(out.metr.PFA_top); title('PFA_{top}');
+                saveas(f, fullfile(figdir,'PFA_top.png')); close(f);
+            catch
+            end
+        end
+    catch
+    end
+end
+
+%% Policy results
+if ~isempty(varargin)
+    P = varargin{1};
+    try
+        pol = {P.policy}';
+        ord = {P.order}';
+        cd  = [P.cooldown_s]';
+        qc_pass = arrayfun(@(s) s.qc.pass_fraction, P)';
+        qc_n    = arrayfun(@(s) s.qc.n, P)';
+        PFA_w   = arrayfun(@(s) max(s.summary.PFA_nom), P)';
+        IDR_w   = arrayfun(@(s) max(s.summary.IDR_nom), P)';
+        PFA_ws  = arrayfun(@(s) max(s.summary.PFA_worst), P)';
+        IDR_ws  = arrayfun(@(s) max(s.summary.IDR_worst), P)';
+        idx_tbl = table(pol, ord, cd, qc_pass, qc_n, PFA_w, IDR_w, PFA_ws, IDR_ws, ...
+            'VariableNames',{'policy','order','cooldown_s','qc_pass_frac','qc_n', ...
+                             'PFA_w','IDR_w','PFA_worst','IDR_worst'});
+        writetable(idx_tbl, fullfile(outdir,'policy_index.csv'));
+        for i = 1:numel(P)
+            fname = sprintf('policy_%s_%s_cd%s.csv', ...
+                sanitize_name(P(i).policy), sanitize_name(P(i).order), ...
+                sanitize_name(num2str(P(i).cooldown_s)));
+            writetable(P(i).summary, fullfile(outdir,fname));
+        end
+    catch
+    end
+end
+end

--- a/2/run_batch_windowed.m
+++ b/2/run_batch_windowed.m
@@ -16,6 +16,21 @@ function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 if nargin < 3, opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
+
+do_export = isfield(opts,'do_export') && opts.do_export;
+if do_export
+    if isfield(opts,'outdir')
+        outdir = opts.outdir;
+    else
+        ts = datestr(now,'yyyymmdd_HHMMSS');
+        outdir = fullfile('out', ts);
+    end
+    if ~exist(outdir,'dir'), mkdir(outdir); end
+    diary(fullfile(outdir,'console.log'));
+else
+    outdir = '';
+end
+
 n = numel(scaled);
 
 all_out = cell(n,1);
@@ -142,5 +157,10 @@ summary.all_out = all_out;
 
 fprintf('Worst PFA: %s, mu=%.2f\n', worstPFA_name, worstPFA_mu);
 fprintf('Worst IDR: %s, mu=%.2f\n', worstIDR_name, worstIDR_mu);
+
+if do_export
+    export_results(outdir, scaled, params, opts, summary, all_out);
+    diary off;
+end
 
 end

--- a/2/run_one_record_windowed.m
+++ b/2/run_one_record_windowed.m
@@ -212,6 +212,7 @@ out.which_peak = which_peak;
 out.mu_results = mu_results;
 out.weighted = weighted;
 out.worst = worst;
+out.ts = ts;
 out.qc_all_mu = all(arrayfun(@(s) s.qc.pass, mu_results));
 out.T_start = T_start;
 out.T_end = T_end;

--- a/2/sanitize_name.m
+++ b/2/sanitize_name.m
@@ -1,0 +1,8 @@
+function s = sanitize_name(s)
+%SANITIZE_NAME Replace non-alphanumeric characters for safe file names.
+%   S2 = SANITIZE_NAME(S) replaces characters outside [a-zA-Z0-9_\- ] with '_'.
+if ~ischar(s) && ~isstring(s)
+    s = char(s);
+end
+s = regexprep(char(s),'[^a-zA-Z0-9_\- ]','_');
+end

--- a/2/writejson.m
+++ b/2/writejson.m
@@ -1,0 +1,13 @@
+function writejson(data, filename)
+%WRITEJSON Minimal JSON writer using JSONENCODE.
+try
+    txt = jsonencode(data);
+    fid = fopen(filename,'w');
+    if fid~=-1
+        fwrite(fid, txt);
+        fclose(fid);
+    end
+catch
+    % silently ignore
+end
+end


### PR DESCRIPTION
## Summary
- add optional export layer that writes logs and results to timestamped `out/` directory
- capture time-series data and downsample for per-record details
- support policy result export with index tables and snapshot metadata

## Testing
- `apt-get update`
- `apt-get install -y octave` *(fails: Unable to locate package)*
- `octave --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d7055ae88328bc69b6ee35162e79