### PR TITLE
Add export toggle for damperlinon

### DIFF
--- a/2/downsample_ts.m
+++ b/2/downsample_ts.m
@@ -1,0 +1,16 @@
+function ts_ds = downsample_ts(ts, ds)
+%DOWNSAMPLE_TS Downsample all numeric fields in a struct.
+%   TS_DS = DOWNSAMPLE_TS(TS, DS) keeps every DS-th row of numeric array fields.
+if nargin < 2 || isempty(ds), ds = 5; end
+fns = fieldnames(ts);
+ts_ds = struct();
+for i = 1:numel(fns)
+    val = ts.(fns{i});
+    if isnumeric(val) && ~isscalar(val)
+        idx = 1:ds:size(val,1);
+        ts_ds.(fns{i}) = val(idx,:,:);
+    else
+        ts_ds.(fns{i}) = val;
+    end
+end
+end

--- a/2/export_results.m
+++ b/2/export_results.m
@@ -1,0 +1,140 @@
+function export_results(outdir, scaled, params, opts, summary, all_out, varargin)
+%EXPORT_RESULTS Persist results to out/<timestamp>/ directory.
+%   EXPORT_RESULTS(OUTDIR, SCALED, PARAMS, OPTS, SUMMARY, ALL_OUT)
+%   writes various logs and per-record details.  Optional additional
+%   structures (e.g., policy results) may be passed in VARARGIN.
+
+if nargin < 1 || isempty(outdir), return; end
+if ~exist(outdir,'dir'), mkdir(outdir); end
+
+%% Meta/snapshot
+try
+    save(fullfile(outdir,'snapshot.mat'), 'params','opts','scaled','-v7.3');
+catch
+end
+try
+    names = {scaled.name}';
+    dt = arrayfun(@(s) getfield(s,'dt',NaN), scaled)'; %#ok<GFLD>
+    dur = arrayfun(@(s) getfield(s,'duration',NaN), scaled)'; %#ok<GFLD>
+    PGA = arrayfun(@(s) getfield(s,'PGA',NaN), scaled)'; %#ok<GFLD>
+    PGV = arrayfun(@(s) getfield(s,'PGV',NaN), scaled)'; %#ok<GFLD>
+    IM  = arrayfun(@(s) getfield(s,'IM',NaN), scaled)'; %#ok<GFLD>
+    sc  = arrayfun(@(s) getfield(s,'scale',NaN), scaled)'; %#ok<GFLD>
+    tbl = table(names, dt, dur, PGA, PGV, IM, sc, ...
+        'VariableNames',{'name','dt','dur','PGA','PGV','IM','scale'});
+    writetable(tbl, fullfile(outdir,'scaled_index.csv'));
+catch
+end
+
+%% Summaries
+try
+    writetable(summary.table, fullfile(outdir,'summary.csv'));
+catch
+end
+try
+    save(fullfile(outdir,'summary_full.mat'), 'summary','all_out','-v7.3');
+catch
+end
+try
+    pass = sum(summary.table.qc_all_mu);
+    fail = height(summary.table) - pass;
+    [~,idx] = maxk(summary.table.PFA_worst, min(3,height(summary.table)));
+    worst = summary.table.name(idx);
+    qc_tbl = table(pass, fail, worst, 'VariableNames',{'pass','fail','worst'});
+    writetable(qc_tbl, fullfile(outdir,'qc_summary.csv'));
+catch
+end
+
+%% Record-based details
+for k = 1:numel(all_out)
+    out = all_out{k};
+    try
+        recdir = fullfile(outdir, ['rec-' sanitize_name(out.name)]);
+        if ~exist(recdir,'dir'), mkdir(recdir); end
+        % window.json
+        try
+            w = out.win;
+            win_struct = struct('t5',w.t5,'t95',w.t95,'pad',getfield(w,'pad',0), ...
+                                'coverage',w.coverage);
+            writejson(win_struct, fullfile(recdir,'window.json'));
+        catch
+        end
+        % mu_results.csv
+        if isfield(out,'mu_results') && ~isempty(out.mu_results)
+            try
+                mu_tbl = struct2table(arrayfun(@(s) s.metr, out.mu_results));
+                mu_tbl.mu = [out.mu_results.mu_factor]';
+                mu_tbl = movevars(mu_tbl,'mu','before',1);
+                writetable(mu_tbl, fullfile(recdir,'mu_results.csv'));
+            catch
+            end
+        end
+        % metrics_win.csv
+        try
+            m = out.metr;
+            mstruct = struct('PFA_top',m.PFA_top,'IDR_max',m.IDR_max, ...
+                             'dP95',m.dP_orf_q95,'Qcap95',m.Qcap_ratio_q95, ...
+                             'cav_pct',m.cav_pct,'T_end',out.T_end,'mu_end',out.mu_end);
+            if isfield(m,'E_orifice_win'), mstruct.E_orf_win = m.E_orifice_win; end
+            if isfield(m,'E_struct_win'), mstruct.E_struct_win = m.E_struct_win; end
+            metr_tbl = struct2table(mstruct);
+            writetable(metr_tbl, fullfile(recdir,'metrics_win.csv'));
+        catch
+        end
+        % ts_ds.mat
+        if isfield(out,'ts') && ~isempty(out.ts)
+            try
+                ds = 5;
+                if isfield(opts,'export') && isfield(opts.export,'ds')
+                    ds = opts.export.ds;
+                end
+                ts_ds = downsample_ts(out.ts, ds);
+                save(fullfile(recdir,'ts_ds.mat'),'ts_ds','-v7.3');
+            catch
+            end
+        end
+        % optional plots
+        if isfield(opts,'export') && isfield(opts.export,'plots') && opts.export.plots
+            try
+                figdir = fullfile(recdir,'figures');
+                if ~exist(figdir,'dir'), mkdir(figdir); end
+                f = figure('Visible','off');
+                bar(out.metr.IDR_max); title('IDR_{max}');
+                saveas(f, fullfile(figdir,'IDR_max.png')); close(f);
+                f = figure('Visible','off');
+                bar(out.metr.PFA_top); title('PFA_{top}');
+                saveas(f, fullfile(figdir,'PFA_top.png')); close(f);
+            catch
+            end
+        end
+    catch
+    end
+end
+
+%% Policy results
+if ~isempty(varargin)
+    P = varargin{1};
+    try
+        pol = {P.policy}';
+        ord = {P.order}';
+        cd  = [P.cooldown_s]';
+        qc_pass = arrayfun(@(s) s.qc.pass_fraction, P)';
+        qc_n    = arrayfun(@(s) s.qc.n, P)';
+        PFA_w   = arrayfun(@(s) max(s.summary.PFA_nom), P)';
+        IDR_w   = arrayfun(@(s) max(s.summary.IDR_nom), P)';
+        PFA_ws  = arrayfun(@(s) max(s.summary.PFA_worst), P)';
+        IDR_ws  = arrayfun(@(s) max(s.summary.IDR_worst), P)';
+        idx_tbl = table(pol, ord, cd, qc_pass, qc_n, PFA_w, IDR_w, PFA_ws, IDR_ws, ...
+            'VariableNames',{'policy','order','cooldown_s','qc_pass_frac','qc_n', ...
+                             'PFA_w','IDR_w','PFA_worst','IDR_worst'});
+        writetable(idx_tbl, fullfile(outdir,'policy_index.csv'));
+        for i = 1:numel(P)
+            fname = sprintf('policy_%s_%s_cd%s.csv', ...
+                sanitize_name(P(i).policy), sanitize_name(P(i).order), ...
+                sanitize_name(num2str(P(i).cooldown_s)));
+            writetable(P(i).summary, fullfile(outdir,fname));
+        end
+    catch
+    end
+end
+end

--- a/2/mck_with_damper.m
+++ b/2/mck_with_damper.m
@@ -1,0 +1,137 @@
+function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0, use_orf,orf,rho,Ap,Ao,Qcap, mu_ref, ...
+    use_thermal, thermal, T0_C,T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
+    cp_oil,cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
+    n_dampers_per_story, resFactor, cfg)
+
+    n = size(M,1); r = ones(n,1);
+    agf = griddedInterpolant(t,ag,'linear','nearest');
+    z0 = zeros(2*n,1);
+    opts= odeset('RelTol',1e-3,'AbsTol',1e-6);
+
+    % Story vectors
+    nStories = n-1;
+    Rvec = toggle_gain(:); if numel(Rvec)==1, Rvec = Rvec*ones(nStories,1); end
+    mask = story_mask(:);  if numel(mask)==1,  mask  = mask *ones(nStories,1); end
+    ndps = n_dampers_per_story(:); if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
+    multi= (mask .* ndps).';
+    Rvec = Rvec.';
+    Nvec = 1:nStories; Mvec = 2:n;
+
+    % Initial temperature and viscosity
+    Tser = T0_C*ones(numel(t),1);
+    mu_abs = mu_ref;
+    c_lam = c_lam0;
+
+    % Solve ODE
+    odef = @(tt,z) [ z(n+1:end); M \ ( -C*z(n+1:end) - K*z(1:n) - dev_force(tt,z(1:n),z(n+1:end),c_lam,mu_abs) - M*r*agf(tt) ) ];
+    sol  = ode15s(odef,[t(1) t(end)],z0,opts);
+    z    = deval(sol,t).';
+    x    = z(:,1:n); v = z(:,n+1:end);
+
+    drift = x(:,Mvec) - x(:,Nvec);
+    dvel  = v(:,Mvec) - v(:,Nvec);
+    drift_p = drift .* Rvec; dvel_p = dvel .* Rvec;
+    F_lin_p = k_sd*drift_p + c_lam*dvel_p;
+
+    if use_orf
+        qmag = Qcap * tanh( (Ap/Qcap) * sqrt(dvel_p.^2 + orf.veps^2) );
+        Re   = (rho .* qmag ./ max(Ao*mu_abs,1e-9)) .* max(orf.d_o,1e-9);
+        Cd   = orf.CdInf - (orf.CdInf - orf.Cd0) ./ (1 + (Re./orf.Rec).^orf.p_exp);
+        dP_calc = 0.5*rho .* ( qmag ./ max(Cd.*Ao,1e-9) ).^2;
+        p_up   = orf.p_amb + abs(F_lin_p)./max(Ap,1e-12);
+        dP_cav = max( (p_up - orf.p_cav_eff).*orf.cav_sf, 0 );
+        dP_orf = softmin(dP_calc,dP_cav,1e5);
+        sgn = dvel_p ./ sqrt(dvel_p.^2 + orf.veps^2);
+        F_orf_p = dP_orf .* Ap .* sgn;
+        F_p = F_lin_p + F_orf_p;
+        Q = Ap * sqrt(dvel_p.^2 + orf.veps^2);
+        P_orf_per = dP_orf .* Q;
+    else
+        F_p = F_lin_p; Q = 0*dvel_p; dP_orf = 0*dvel_p; P_orf_per = 0*dvel_p;
+    end
+
+    dp_pf = (c_lam*dvel_p + (F_p - k_sd*drift_p)) ./ Ap;
+    if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
+        s = tanh(20*dvel_p);
+        dp_pf = s .* max(0, s .* dp_pf);
+    end
+    w_pf_vec = pf_weight(t, cfg) * cfg.PF.gain;
+    F_p = k_sd*drift_p + (w_pf_vec .* dp_pf) * Ap;
+
+    F_story = F_p .* (Rvec .* multi);
+    P_visc_per = c_lam * (dvel_p.^2);
+    P_sum = sum( (P_visc_per + P_orf_per) .* multi, 2 );
+    energy = cumtrapz(t,P_sum);
+    P_orf_tot = sum(P_orf_per .* multi, 2);
+    P_struct_tot = sum(F_story .* dvel .* multi, 2);
+    E_orifice = trapz(t, P_orf_tot);
+    E_struct = trapz(t, P_struct_tot);
+    P_mech = mean(P_struct_tot);
+
+    % Thermal response
+    nDtot = sum(multi);
+    V_oil_per = resFactor*(Ap*(2*Lgap));
+    m_oil_tot = nDtot*(rho*V_oil_per);
+    m_steel_tot = steel_to_oil_mass_ratio*m_oil_tot;
+    C_th = max(m_oil_tot*cp_oil + m_steel_tot*cp_steel, eps);
+    dtv = diff(t);
+    for k=1:numel(t)-1
+        Pk = 0.5*(P_sum(k)+P_sum(k+1));
+        Tser(k+1) = Tser(k) + dtv(k)*( Pk/C_th - (thermal.hA_W_perK/C_th)*(Tser(k)-thermal.T_env_C) );
+        Tser(k+1) = min(max(Tser(k+1), T0_C), T0_C + thermal.dT_max);
+    end
+    mu = mu_ref*exp(b_mu*(Tser - T_ref_C));
+
+    % Node forces for acceleration
+    F = zeros(numel(t),n);
+    F(:,Nvec) = F(:,Nvec) - F_story;
+    F(:,Mvec) = F(:,Mvec) + F_story;
+    a = ( -(M\(C*v.' + K*x.' + F.')).' - ag.*r.' );
+
+    diag = struct('drift',drift,'dvel',dvel,'story_force',F_story,'Q',Q, ...
+        'dP_orf',dP_orf,'PF',F_p,'T_oil',Tser,'T_steel',Tser,'mu',mu, ...
+        'energy',energy,'P_sum',P_sum,'c_lam',c_lam, ...
+        'E_orifice',E_orifice,'E_struct',E_struct,'P_mech',P_mech);
+
+    function Fd = dev_force(tt,x_,v_,c_lam_loc,mu_abs_loc)
+        Rcol = Rvec.';
+        multicol = multi.';
+        drift_ = x_(Mvec) - x_(Nvec);
+        dvel_  = v_(Mvec) - v_(Nvec);
+        drift_p_ = drift_ .* Rcol;
+        dvel_p_  = dvel_  .* Rcol;
+        F_lin_p_ = k_sd*drift_p_ + c_lam_loc*dvel_p_;
+        if ~use_orf
+            F_orf_p_ = 0*dvel_p_;
+        else
+            qmag_ = Qcap * tanh( (Ap/Qcap) * sqrt(dvel_p_.^2 + orf.veps^2) );
+            Re_   = (rho .* qmag_ ./ max(Ao*mu_abs_loc,1e-9)) .* max(orf.d_o,1e-9);
+            Cd_   = orf.CdInf - (orf.CdInf - orf.Cd0) ./ (1 + (Re_./orf.Rec).^orf.p_exp);
+            dP_calc_ = 0.5*rho .* ( qmag_ ./ max(Cd_.*Ao,1e-9) ).^2;
+            p_up_   = orf.p_amb + abs(F_lin_p_)./max(Ap,1e-12);
+            dP_cav_ = max( (p_up_ - orf.p_cav_eff).*orf.cav_sf, 0 );
+            dP_orf_ = softmin(dP_calc_,dP_cav_,1e5);
+            sgn_ = dvel_p_ ./ sqrt(dvel_p_.^2 + orf.veps^2);
+            F_orf_p_ = dP_orf_ .* Ap .* sgn_;
+        end
+        dp_pf_ = (c_lam_loc*dvel_p_ + F_orf_p_) ./ Ap;
+        if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
+            s = tanh(20*dvel_p_);
+            dp_pf_ = s .* max(0, s .* dp_pf_);
+        end
+        w_pf = pf_weight(tt,cfg) * cfg.PF.gain;
+        F_p_ = k_sd*drift_p_ + (w_pf .* dp_pf_) * Ap;
+        F_story_ = F_p_ .* (Rcol .* multicol);
+        Fd = zeros(n,1);
+    Fd(Nvec) = Fd(Nvec) - F_story_;
+    Fd(Mvec) = Fd(Mvec) + F_story_;
+    end
+end
+
+function w = pf_weight(t, cfg)
+    w = cfg.on.pressure_force * (1 - exp(-max(t - cfg.PF.t_on, 0) ./ max(cfg.PF.tau, 1e-6)));
+end
+
+function y = softmin(a,b,epsm)
+    y = 0.5*(a + b - sqrt((a - b).^2 + epsm.^2));
+end

--- a/2/run_batch_windowed.m
+++ b/2/run_batch_windowed.m
@@ -16,6 +16,21 @@ function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 if nargin < 3, opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
+
+do_export = isfield(opts,'do_export') && opts.do_export;
+if do_export
+    if isfield(opts,'outdir')
+        outdir = opts.outdir;
+    else
+        ts = datestr(now,'yyyymmdd_HHMMSS');
+        outdir = fullfile('out', ts);
+    end
+    if ~exist(outdir,'dir'), mkdir(outdir); end
+    diary(fullfile(outdir,'console.log'));
+else
+    outdir = '';
+end
+
 n = numel(scaled);
 
 all_out = cell(n,1);
@@ -142,5 +157,10 @@ summary.all_out = all_out;
 
 fprintf('Worst PFA: %s, mu=%.2f\n', worstPFA_name, worstPFA_mu);
 fprintf('Worst IDR: %s, mu=%.2f\n', worstIDR_name, worstIDR_mu);
+
+if do_export
+    export_results(outdir, scaled, params, opts, summary, all_out);
+    diary off;
+end
 
 end

--- a/2/run_one_record_windowed.m
+++ b/2/run_one_record_windowed.m
@@ -212,6 +212,7 @@ out.which_peak = which_peak;
 out.mu_results = mu_results;
 out.weighted = weighted;
 out.worst = worst;
+out.ts = ts;
 out.qc_all_mu = all(arrayfun(@(s) s.qc.pass, mu_results));
 out.T_start = T_start;
 out.T_end = T_end;

--- a/2/sanitize_name.m
+++ b/2/sanitize_name.m
@@ -1,0 +1,8 @@
+function s = sanitize_name(s)
+%SANITIZE_NAME Replace non-alphanumeric characters for safe file names.
+%   S2 = SANITIZE_NAME(S) replaces characters outside [a-zA-Z0-9_\- ] with '_'.
+if ~ischar(s) && ~isstring(s)
+    s = char(s);
+end
+s = regexprep(char(s),'[^a-zA-Z0-9_\- ]','_');
+end

--- a/2/writejson.m
+++ b/2/writejson.m
@@ -1,0 +1,13 @@
+function writejson(data, filename)
+%WRITEJSON Minimal JSON writer using JSONENCODE.
+try
+    txt = jsonencode(data);
+    fid = fopen(filename,'w');
+    if fid~=-1
+        fwrite(fid, txt);
+        fclose(fid);
+    end
+catch
+    % silently ignore
+end
+end


### PR DESCRIPTION
## Summary
- Add `do_export` flag to `damperlinon.m` to toggle saving outputs to `out/<timestamp>/`
- When enabled, create run directory with console diary and export results via `export_results`
- Provide standalone `mck_with_damper` solver shared by batch/policy runs

## Testing
- `apt-get update` *(warning: some index files failed to download; old ones used)*
- `apt-get install -y octave` *(fails: ca-certificates-java post-installation script error)*
- `octave --version`
- `octave -qf --eval "cd 2; disp(which('mck_with_damper'));"`
- `octave -qf --eval "cd 2; try; damperlinon; catch err; disp(err.message); end"` *(fails: nested functions not implemented in this context)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d7055ae88328bc69b6ee35162e79