### PR TITLE
Add helper for safe field access to avoid getfield errors

### DIFF
--- a/2/export_results.m
+++ b/2/export_results.m
@@ -14,12 +14,12 @@ catch
 end
 try
     names = {scaled.name}';
-    dt = arrayfun(@(s) getfield(s,'dt',NaN), scaled)'; %#ok<GFLD>
-    dur = arrayfun(@(s) getfield(s,'duration',NaN), scaled)'; %#ok<GFLD>
-    PGA = arrayfun(@(s) getfield(s,'PGA',NaN), scaled)'; %#ok<GFLD>
-    PGV = arrayfun(@(s) getfield(s,'PGV',NaN), scaled)'; %#ok<GFLD>
-    IM  = arrayfun(@(s) getfield(s,'IM',NaN), scaled)'; %#ok<GFLD>
-    sc  = arrayfun(@(s) getfield(s,'scale',NaN), scaled)'; %#ok<GFLD>
+    dt = arrayfun(@(s) getfield_default(s,'dt',NaN), scaled)';
+    dur = arrayfun(@(s) getfield_default(s,'duration',NaN), scaled)';
+    PGA = arrayfun(@(s) getfield_default(s,'PGA',NaN), scaled)';
+    PGV = arrayfun(@(s) getfield_default(s,'PGV',NaN), scaled)';
+    IM  = arrayfun(@(s) getfield_default(s,'IM',NaN), scaled)';
+    sc  = arrayfun(@(s) getfield_default(s,'scale',NaN), scaled)';
     tbl = table(names, dt, dur, PGA, PGV, IM, sc, ...
         'VariableNames',{'name','dt','dur','PGA','PGV','IM','scale'});
     writetable(tbl, fullfile(outdir,'scaled_index.csv'));
@@ -54,7 +54,7 @@ for k = 1:numel(all_out)
         % window.json
         try
             w = out.win;
-            win_struct = struct('t5',w.t5,'t95',w.t95,'pad',getfield(w,'pad',0), ...
+            win_struct = struct('t5',w.t5,'t95',w.t95,'pad',getfield_default(w,'pad',0), ...
                                 'coverage',w.coverage);
             writejson(win_struct, fullfile(recdir,'window.json'));
         catch

--- a/2/getfield_default.m
+++ b/2/getfield_default.m
@@ -1,0 +1,25 @@
+function v = getfield_default(S, fname, defaultVal)
+%GETFIELD_DEFAULT Safe field access with default value.
+%   v = GETFIELD_DEFAULT(S, fname, defaultVal) returns the value of the field
+%   FNAME from struct S if it exists and is non-empty. If the field is
+%   missing, empty, or contains non-finite numeric values, DEFAULTVAL is
+%   returned instead.
+
+    if ~isstruct(S) || ~isfield(S, fname) || isempty(S.(fname))
+        v = defaultVal;
+        return;
+    end
+
+    val = S.(fname);
+    if isnumeric(val)
+        if isempty(val) || any(~isfinite(val(:)))
+            v = defaultVal;
+        else
+            v = val;
+        end
+    else
+        % For non-numeric types, only emptiness is checked.
+        v = val;
+    end
+end
+

--- a/2/run_batch_windowed.m
+++ b/2/run_batch_windowed.m
@@ -43,8 +43,10 @@ t95      = zeros(n,1);
 coverage = zeros(n,1);
 
 % policy/order info
-policy_col   = repmat({getfield(opts,'thermal_reset','each')}, n,1);
-order_col    = repmat({getfield(opts,'order','natural')}, n,1);
+policy_val = getfield_default(opts,'thermal_reset','each');
+order_val  = getfield_default(opts,'order','natural');
+policy_col = repmat({policy_val}, n,1);
+order_col  = repmat({order_val}, n,1);
 if isfield(opts,'cooldown_s')
     cooldown_val = opts.cooldown_s;
 else

--- a/2/run_one_record_windowed.m
+++ b/2/run_one_record_windowed.m
@@ -201,8 +201,8 @@ end
 %% ----------------------- Assemble output ----------------------------
 out = struct();
 out.name  = rec.name;
-out.scale = getfield(rec,'scale',1); %#ok<GFLD>
-out.SaT1  = getfield(rec,'IM',NaN); %#ok<GFLD>
+out.scale = getfield_default(rec,'scale',1);
+out.SaT1  = getfield_default(rec,'IM',NaN);
 out.win   = win;
 out.metr  = metr;
 out.metr0 = metr0;


### PR DESCRIPTION
## Summary
- Introduce `getfield_default` utility for safe struct field lookup with defaults
- Use the new helper in record processing and export utilities to handle missing fields gracefully

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0b1469c8328b0147b56eb47aecb