### PR TITLE
Remove logging and plotting from GA utilities

### DIFF
--- a/3/GA/export_results.m
+++ b/3/GA/export_results.m
@@ -147,20 +147,6 @@ for k = 1:numel(all_out)
             catch
             end
         end
-        % optional plots
-        if isfield(opts,'export') && isfield(opts.export,'plots') && opts.export.plots
-            try
-                figdir = fullfile(recdir,'figures');
-                if ~exist(figdir,'dir'), mkdir(figdir); end
-                f = figure('Visible','off');
-                bar(out.metr.IDR_max); title('IDR_{max}');
-                saveas(f, fullfile(figdir,'IDR_max.png')); close(f);
-                f = figure('Visible','off');
-                bar(out.metr.PFA_top); title('PFA_{top}');
-                saveas(f, fullfile(figdir,'PFA_top.png')); close(f);
-            catch
-            end
-        end
     catch
     end
 end

--- a/3/GA/load_ground_motions.m
+++ b/3/GA/load_ground_motions.m
@@ -81,13 +81,6 @@ for k = 1:numel(fn)
                             'IM', [], 'scale', 1); %#ok<AGROW>
 end
 
-% Print a quick summary table
-fprintf('Loaded %d ground-motion records:\n', numel(records));
-for k = 1:numel(records)
-    r = records(k);
-    fprintf('%2d) %-12s dt=%6.4f s dur=%6.2f s PGA=%7.3f PGV=%7.3f\n', ...
-        k, r.name, r.dt, r.duration, r.PGA, r.PGV);
-end
 
 scaled = [];
 meta = struct();
@@ -136,9 +129,6 @@ for it = 1:max_iter
     dropped{end+1} = records(idx).name; %#ok<AGROW>
     records(idx) = [];   % kaydı at
     IM(idx) = [];
-end
-if ~isempty(dropped)
-    fprintf('TRIM: dropped outliers = %s\n', strjoin(dropped,', '));
 end
 % Sonra targetIM = min(max(median(IM), IM_low), IM_high) ile devam...
 % TRIM sonrasi hedef ve clip durumunu guncelle
@@ -191,15 +181,7 @@ else
     modeStr = 'PSA@T1';
 end
 
-fprintf('Target IM = %.3f (%s). Max error = %.2f%% | feasible=[%.3f, %.3f] | s_min=%.2f s_max=%.2f', ...
-    targetIM, modeStr, max(err), IM_low, IM_high, min(s_all), max(s_all));
 
-if doClip
-    fprintf(' | CLIPPED=%d', n_clipped);
-else
-    fprintf(' | CLIPPED=0');
-end
-fprintf('\n');
 
 % meta bilgileri (opsiyonel 3. cikti)
 meta.IM_mode    = IM_mode;

--- a/3/GA/make_sizing_case.m
+++ b/3/GA/make_sizing_case.m
@@ -191,13 +191,6 @@ function [sizing, P_sized, S_worst] = make_sizing_case(scaled, params, gainsPF, 
     % --- rapor: parametre.m içinde hangi satırlar değişecek?
 try
     [updates, T] = sizing_param_diff(params, P_sized, gainsPF, sizing); %#ok<NASGU>
-    % İstersen otomatik patch için konsola hazır satırları da yaz:
-    fprintf('parametre.m için önerilen satırlar:\n');
-    for i=1:numel(updates.lines)
-        fprintf('  %s\n', updates.lines{i});
-    end
-    fprintf('  %% toggle_gain vektörü:\n  toggle_gain = %s;  %% (n-1)x1\n', mat2str(updates.toggle_gain_vec,3));
-catch ME
-    warning('sizing_param_diff failed: %s', ME.message);
+catch
 end
 end

--- a/3/GA/parpool_hard_reset.m
+++ b/3/GA/parpool_hard_reset.m
@@ -15,12 +15,11 @@ function parpool_hard_reset(nWorkers)
             pctRunOnAll setenv('OMP_NUM_THREADS','1');
             pctRunOnAll setenv('MKL_NUM_THREADS','1');
         catch, end
-    catch ME
-        warning('[parpool_hard_reset] %s', ME.message);
-        try
-            p = gcp('nocreate'); if ~isempty(p), return; end
-            parpool('Threads');
-        catch, end
-    end
+catch
+    try
+        p = gcp('nocreate'); if ~isempty(p), return; end
+        parpool('Threads');
+    catch, end
+end
 end
 

--- a/3/GA/run_batch_windowed.m
+++ b/3/GA/run_batch_windowed.m
@@ -26,9 +26,6 @@ if do_export
         outdir = fullfile('out', ts);
     end
     if ~exist(outdir,'dir'), mkdir(outdir); end
-    if ~Utils.getfield_default(opts,'quiet',false)
-        diary(fullfile(outdir,'console.log'));
-    end
 else
     outdir = '';
 end
@@ -249,16 +246,8 @@ summary.table.ok_Qcap = ok_Qcap;
 summary.table.ok_cav = ok_cav;
 summary.table.qc_reason = qc_reason;
 
-if ~isfield(opts,'quiet') || ~opts.quiet
-    fprintf('Worst PFA: %s, mu=%.2f\n', worstPFA_name, worstPFA_mu);
-    fprintf('Worst IDR: %s, mu=%.2f\n', worstIDR_name, worstIDR_mu);
-end
-
 if do_export
     export_results(outdir, scaled, params, opts, summary, all_out);
-    if ~Utils.getfield_default(opts,'quiet',false)
-        diary off;
-    end
 end
 
 end
@@ -313,31 +302,8 @@ quiet = isfield(opts,'quiet') && opts.quiet;
 % Default to exporting results for policy runs unless explicitly disabled
 do_export = ~isfield(opts,'do_export') || opts.do_export;
 ts = datestr(now,'yyyymmdd_HHMMSS_FFF'); outdir = fullfile('out', ts);
-if do_export && ~quiet
-    if ~exist(outdir,'dir'), mkdir(outdir); end
-    diary(fullfile(outdir,'console.log'));
-else
-    if ~exist(outdir,'dir'), mkdir(outdir); end
-end
+if ~exist(outdir,'dir'), mkdir(outdir); end
 
-% Console header
-try
-    imode = Utils.getfield_default(opts,'IM_mode','');
-    band  = Utils.getfield_default(opts,'band_fac',[NaN NaN]);
-    sb    = Utils.getfield_default(opts,'s_bounds',[NaN NaN]);
-    if ~quiet
-        fprintf('Run @ %s | outdir=%s\n', ts, outdir);
-        fprintf('IM_mode=%s, band=[%.3g,%.3g], s_bounds=[%.2f,%.2f]\n', imode, band(1), band(2), sb(1), sb(2));
-        fprintf('policies=%s | orders=%s | cooldown_s_list=%s | rng_seed=%d\n', ...
-            strjoin(opts.policies,','), strjoin(opts.orders,','), sprintf('%d ', opts.cooldown_s_list), opts.rng_seed);
-        if isfield(opts,'TRIM_names') && ~isempty(opts.TRIM_names)
-            fprintf('TRIM: %s\n', strjoin(opts.TRIM_names,', '));
-        end
-        fprintf('QC thr: dP95<=%.1f MPa, Qcap95<%.2f, cav%%=%g, T_end<=%g C, mu_end>=%0.2f Pa*s\n', ...
-            opts.thr.dP95_max/1e6, opts.thr.Qcap95_max, opts.thr.cav_pct_max*100, opts.thr.T_end_max, opts.thr.mu_end_min);
-    end
-catch
-end
 
 % Echo hydraulic/thermal key params
 try
@@ -349,10 +315,6 @@ try
     resFactor = Utils.getfield_default(params,'resFactor',NaN);
     tg = Utils.getfield_default(params,'toggle_gain',NaN);
     tgv = tg(:); tgmin = min(tgv); tgmed = median(tgv); tgmax = max(tgv);
-    if ~quiet
-        fprintf('Hydraulics: n_orf=%g, d_o~=%g m, A_o=%s, Qcap_big=%g, hA=%g, resFactor=%g, toggle_gain[min/med/max]=[%g %g %g]\n', ...
-            n_orf, d_o, mat2str(size(A_o)), Qcap_big, hA, resFactor, tgmin, tgmed, tgmax);
-    end
 catch
 end
 
@@ -372,11 +334,7 @@ base_cav_worst_max = max(base_summary.table.cav_pct_worst);
 base_mu_end_worst_min = min(base_summary.table.mu_end_worst);
 base_qc_pass = sum(base_summary.table.qc_all_mu);
 base_qc_n = height(base_summary.table);
-if ~quiet
-    fprintf(['BASE (each/natural): PFA_w=%.3g, IDR_w=%.3g, dP95_worst=%.3g MPa, Qcap95_worst=%.2f, ' ...
-            'cav%%_worst=%.1f, T_end_worst=%.1f C, mu_end_worst=%.2f, qc_rate=%d/%d\n'], ...
-        basePFA_w_mean, baseIDR_w_mean, base_dP95_worst_max/1e6, base_Qcap95_worst_max, base_cav_worst_max*100, baseTend_worst, base_mu_end_worst_min, base_qc_pass, base_qc_n);
-end
+
 
 % Pre-compute orders
 orders_struct.natural = 1:nRec;
@@ -399,9 +357,6 @@ if any(strcmp(opts.orders,'worst_first'))
     orders_struct.worst_first = idx;
     try
         rank_names = {scaled(idx).name};
-        if ~quiet
-            fprintf('worst_first ranking by %s: %s\n', opts.rank_metric, strjoin(rank_names, ', '));
-        end
     catch, end
 end
 
@@ -443,59 +398,22 @@ for ip = 1:numel(opts.policies)
             [worstPFA, idxP] = max(summary.table.PFA_worst);
             nP = summary.table.name{idxP};
             muP = summary.table.which_mu_PFA(idxP);
-            if ~quiet, fprintf('Worst PFA (%s,%s,mu=%.2f): %s\n', pol, ord, muP, nP); end
             [worstIDR, idxI] = max(summary.table.IDR_worst); %#ok<NASGU>
             nI = summary.table.name{idxI};
             muI = summary.table.which_mu_IDR(idxI);
-            if ~quiet, fprintf('Worst IDR (%s,%s,mu=%.2f): %s\n', pol, ord, muI, nI); end
 
             % policy comparison rule logging against baseline each/natural
             tolPFA = 0.15 * basePFA_w_mean;
             tolIDR = 0.15 * baseIDR_w_mean;
             passPFA = abs(deltas.PFA_w) <= tolPFA;
             passIDR = abs(deltas.IDR_w) <= tolIDR;
-            if ~quiet
-                fprintf('Delta vs base: dPFA_w=%.4g (|d|<=%.4g? %d), dIDR_w=%.4g (|d|<=%.4g? %d), qc_rate=%.2f\n', ...
-                    deltas.PFA_w, tolPFA, passPFA, deltas.IDR_w, tolIDR, passIDR, qc.pass_fraction);
-            end
 
             % Single-line summary for this combination
             n_pass = sum(summary.table.qc_all_mu);
             n_tot  = height(summary.table);
             PFAw   = curPFA_w_mean; IDRw = curIDR_w_mean; T_end_worst_max = curTend_worst;
             pass_flag_15pct = 'OK'; if ~(passPFA && passIDR), pass_flag_15pct = 'FAIL'; end
-            if ~quiet
-                fprintf(['policy=%s | order=%s | cd=%ds | PFA_w=%.3g (d=%+.2f%%) | IDR_w=%.3g (d=%+.2f%%) | ' ...
-                        'T_end_worst=%.1f C | qc_rate=%d/%d %s\n'], ...
-                    pol, ord, cdval, PFAw, 100*(PFAw-basePFA_w_mean)/max(basePFA_w_mean,eps), ...
-                    IDRw, 100*(IDRw-baseIDR_w_mean)/max(baseIDR_w_mean,eps), T_end_worst_max, n_pass, n_tot, pass_flag_15pct);
-                % Echo worst two records by PFA_worst
-                try
-                    kshow = min(2, height(summary.table));
-                    [~,ix] = maxk(summary.table.PFA_worst, kshow);
-                    if kshow==2
-                        fprintf('  worst2(PFA): %s | %s\n', summary.table.name{ix(1)}, summary.table.name{ix(2)});
-                    elseif kshow==1
-                        fprintf('  worst2(PFA): %s | -\n', summary.table.name{ix(1)});
-                    end
-                catch
-                end
-            end
 
-            % Optional clamp summary
-            try
-                if ~quiet
-                    tot_clamps = sum(summary.table.clamp_hits);
-                    nz_idx = find(summary.table.clamp_hits>0);
-                    nz_names = summary.table.name(nz_idx);
-                    if ~isempty(nz_names)
-                        fprintf('clamp_hits total=%d | records: %s\n', tot_clamps, strjoin(nz_names.', ', '));
-                    else
-                        fprintf('clamp_hits total=%d\n', tot_clamps);
-                    end
-                end
-            catch
-            end
 
             P(end+1) = struct('policy',pol,'order',ord,'cooldown_s',cdval, ...
                 'summary',summary.table,'qc',qc,'deltas',deltas); %#ok<AGROW>
@@ -507,6 +425,5 @@ end
 if do_export
     export_results(outdir, scaled, params, opts, base_summary, base_all, P);
 end
-if ~quiet, fprintf('Saved to %s\n', outdir); end
-if do_export && ~quiet, diary off; end
+ 
 end

--- a/3/GA/run_ga_driver.m
+++ b/3/GA/run_ga_driver.m
@@ -2,8 +2,7 @@ function [X,F,gaout] = run_ga_driver(scaledOrSnap, params, optsEval, optsGA)
 % === SAFE PARPOOL OPEN (cleanup + cap threads) ===
 try
     parpool_hard_reset(16);
-catch ME
-    warning('[run_ga_driver] parpool init: %s', ME.message);
+catch
 end
 %RUN_GA_DRIVER Hybrid GA driver: accepts snapshot path or in-memory structs.
 %   [X,F,GAOUT] = RUN_GA_DRIVER(SCALED_OR_PATH, PARAMS, OPTSEVAL, OPTSGA)
@@ -11,7 +10,7 @@ end
 %     A) Snapshot: run_ga_driver('out/<ts>/snapshot.mat', params?, ...)
 %        Loads 'scaled' (and params if not provided).
 %     B) In-memory: run_ga_driver(scaled, params, ...)
-%   Fitness evaluations have no IO/plots; no re-scaling is performed.
+%   Fitness evaluations have no IO; no re-scaling is performed.
 
     % ---------- Zero-arg convenience: pull from base workspace ----------
     % Avoid referencing missing input args when nargin==0/1 by using locals.
@@ -119,8 +118,6 @@ end
     if ~isfield(optsEval,'mu_factors'), optsEval.mu_factors = meta.mu_factors; end
     if ~isfield(optsEval,'mu_weights'), optsEval.mu_weights = meta.mu_weights; end
     if ~isfield(optsEval,'thr'),        optsEval.thr        = meta.thr; end
-    if ~isfield(optsEval,'export'),     optsEval.export     = struct('plots',false,'ds',inf); end
-    if ~isfield(optsEval,'debug'), optsEval.debug = true; end
 
 
     % ---------- GA options and objective ----------
@@ -132,16 +129,10 @@ end
     ub = [3.60, 6, 4.00, 4.00, 3.60, 1.10, 0.90];
     IntCon = 2;  % n_orf only
 
-    % Pass GA population size into eval for debug windowing
-    try, optsEval.popsize = Utils.getfield_default(optsGA,'PopulationSize',48); catch, end
-    if ~isfield(optsEval,'debug') || isempty(optsEval.debug), optsEval.debug = false; end
-    % Provide dataset signature for memo/debug keys
+    % Provide dataset signature for memo keys
     try, dsig = sum([scaled.IM]) + sum([scaled.PGA]); catch, dsig = 0; end
     optsEval.dsig = dsig;
     obj = @(x) eval_design_fast(x, scaled, params, optsEval); % quantize/clamp inside
-
-    % OutputFcn for generation-level debug reporting (works with parallel)
-    outfun = @(options,state,flag) ga_output_debug(options,state,flag, params, optsEval);
 
     options = optimoptions('gamultiobj', ...
        'PopulationSize',    Utils.getfield_default(optsGA,'PopulationSize',16), ...
@@ -152,8 +143,7 @@ end
        'StallGenLimit',     Utils.getfield_default(optsGA,'StallGenLimit',10), ...
        'DistanceMeasureFcn','distancecrowding', ...
        'UseParallel',       Utils.getfield_default(optsGA,'UseParallel',true), ...
-       'Display','iter','PlotFcn',[], 'FunctionTolerance',1e-3, ...
-       'OutputFcn', outfun);
+       'Display','iter','PlotFcn',[], 'FunctionTolerance',1e-3);
 
     % Provide grid-aligned initial population if none supplied (sparser grid + seeds)
     try
@@ -487,91 +477,6 @@ end
     catch
     end
 
-    % ---------- Optional plots for best design (grafik.m equivalent) ----------
-    try
-        % Determine best design x (knee). T includes baseline in first row.
-        if exist('kidx','var') && kidx >= 2
-            x_best = X(kidx-1,:);
-        else
-            x_best = X(1,:);
-        end
-        x_best = quant_clamp_x(x_best);
-        Pbest  = decode_params_from_x(params, x_best);
-        % Choose record with worst PFA under best design
-        Oplt = struct('do_export',false,'quiet',true,'thermal_reset','each','order','natural', ...
-                      'use_orifice',true,'use_thermal',true, ...
-                      'mu_factors', meta.mu_factors, 'mu_weights', meta.mu_weights, 'thr', meta.thr);
-        [Sbest, ~] = run_batch_windowed(scaled, Pbest, Oplt);
-        [~,krec] = max(Sbest.table.PFA_worst);
-        if ~(isfinite(krec) && krec>=1 && krec<=numel(scaled)), krec = 1; end
-        rec = scaled(krec);
-        t = rec.t; ag = rec.ag; n = size(Pbest.M,1); story_height = Pbest.story_height;
-        % Dampersiz (linear MCK)
-        [x0,a0] = Utils.lin_MCK(t, ag, Pbest.M, Pbest.C0, Pbest.K);
-        % Lineer damper (use_orf=false, thermal off)
-        [x_lin,a_lin] = mck_with_damper(t, ag, Pbest.M, Pbest.C0, Pbest.K, Pbest.k_sd, Pbest.c_lam0, ...
-            false, Pbest.orf, Pbest.rho, Pbest.Ap, Pbest.A_o, Pbest.Qcap_big, Pbest.mu_ref, ...
-            false, Pbest.thermal, Pbest.T0_C, Pbest.T_ref_C, Pbest.b_mu, Pbest.c_lam_min, Pbest.c_lam_cap, Pbest.Lgap, ...
-            Pbest.cp_oil, Pbest.cp_steel, Pbest.steel_to_oil_mass_ratio, Pbest.toggle_gain, Pbest.story_mask, Pbest.n_dampers_per_story, Pbest.resFactor, Pbest.cfg);
-        % Orifisli damper (+thermal)
-        [x_orf,a_orf] = mck_with_damper(t, ag, Pbest.M, Pbest.C0, Pbest.K, Pbest.k_sd, Pbest.c_lam0, ...
-            true, Pbest.orf, Pbest.rho, Pbest.Ap, Pbest.A_o, Pbest.Qcap_big, Pbest.mu_ref, ...
-            true, Pbest.thermal, Pbest.T0_C, Pbest.T_ref_C, Pbest.b_mu, Pbest.c_lam_min, Pbest.c_lam_cap, Pbest.Lgap, ...
-            Pbest.cp_oil, Pbest.cp_steel, Pbest.steel_to_oil_mass_ratio, Pbest.toggle_gain, Pbest.story_mask, Pbest.n_dampers_per_story, Pbest.resFactor, Pbest.cfg);
-        % 10th story signals
-        idx10 = min(10, n);
-        x10_0   = x0(:,idx10);
-        x10_lin = x_lin(:,idx10);
-        x10_orf = x_orf(:,idx10);
-        a10_0   = a0(:,idx10)   + ag;  % absolute
-        a10_lin = a_lin(:,idx10)+ ag;
-        a10_orf = a_orf(:,idx10)+ ag;
-        % Arias window
-        win = Utils.make_arias_window(t, ag);
-        t5 = win.t5; t95 = win.t95;
-        % First-mode period for title
-        try
-            [~,D] = eig(Pbest.K, Pbest.M); w = sqrt(sort(diag(D),'ascend')); T1p = 2*pi/w(1);
-        catch
-            T1p = NaN;
-        end
-        % Plot 1: displacement at top
-        f1h = figure('Name','10. Kat yer degistirme (GA best)','Color','w');
-        plot(t, x10_0,'k','LineWidth',1.4); hold on;
-        plot(t, x10_lin,'b','LineWidth',1.1);
-        plot(t, x10_orf,'r','LineWidth',1.0);
-        yl = ylim; plot([t5 t5],yl,'k--','HandleVisibility','off'); plot([t95 t95],yl,'k--','HandleVisibility','off');
-        grid on; xlabel('t [s]'); ylabel(sprintf('x_{%d}(t) [m]', idx10));
-        title(sprintf('T1=%.3f s | Arias [%.3f, %.3f] s | rec=%s', T1p, t5, t95, char(Utils.getfield_default(rec,'name','1'))));
-        legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
-        % Plot 2: absolute acceleration at top
-        f2h = figure('Name','10. Kat mutlak ivme (GA best)','Color','w');
-        plot(t, a10_0,'k','LineWidth',1.4); hold on;
-        plot(t, a10_lin,'b','LineWidth',1.1);
-        plot(t, a10_orf,'r','LineWidth',1.0);
-        yl = ylim; plot([t5 t5],yl,'k--','HandleVisibility','off'); plot([t95 t95],yl,'k--','HandleVisibility','off');
-        grid on; xlabel('t [s]'); ylabel(sprintf('a_{%d,abs}(t) [m/s^2]', idx10)); legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
-        % Plot 3: max IDR per story
-        drift0    = x0(:,2:end)    - x0(:,1:end-1);
-        drift_lin = x_lin(:,2:end) - x_lin(:,1:end-1);
-        drift_orf = x_orf(:,2:end) - x_orf(:,1:end-1);
-        IDR0    = max(abs(drift0))./story_height;
-        IDR_lin = max(abs(drift_lin))./story_height;
-        IDR_orf = max(abs(drift_orf))./story_height;
-        stories = 1:(n-1);
-        f3h = figure('Name','Maksimum IDR (GA best)','Color','w');
-        plot(stories, IDR0,'k-o','LineWidth',1.4); hold on;
-        plot(stories, IDR_lin,'b-s','LineWidth',1.1);
-        plot(stories, IDR_orf,'r-d','LineWidth',1.0);
-        grid on; xlabel('Kat'); ylabel('Maks IDR [Δx/h]'); legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
-        drawnow;
-    catch ME
-        try
-            warning('[run_ga_driver] GA-best plotting failed: %s', ME.message);
-        catch
-        end
-    end
-
     % Decode top-K designs without running sims
     K = min(10, size(X,1));
     if K > 0
@@ -595,71 +500,6 @@ end
         writetable(top, fullfile(outdir,'ga_topK.csv'));
     end
 
-    % Minimal README
-    fid=fopen(fullfile(outdir,'README.txt'),'w');
-    if fid~=-1
-        fprintf(fid, 'Hybrid GA run: %s\n', date_str);
-        fprintf(fid, 'IM_mode=%s, band_fac=%s, s_bounds=%s\n', ...
-            mat2str(meta.IM_mode), mat2str(meta.band_fac), mat2str(meta.s_bounds));
-        fprintf(fid, 'mu_factors=%s, mu_weights=%s\n', mat2str(meta.mu_factors), mat2str(meta.mu_weights));
-        try
-            fprintf(fid, 'thr=%s\n', jsonencode(meta.thr));
-        catch
-        end
-        fprintf(fid, 'Note: No simulations during packaging. Fitness evals had no IO.\n');
-        fclose(fid);
-    end
-end
-
-function [state, options, optchanged] = ga_output_debug(options, state, flag, params, optsEval)
-%GA_OUTPUT_DEBUG OutputFcn to report unique designs per generation.
-    optchanged = false;
-    try
-        if ~isfield(state,'Population') || isempty(state.Population)
-            return;
-        end
-        if ~(strcmpi(flag,'iter') || strcmpi(flag,'done'))
-            return;
-        end
-        X = state.Population;
-        n = size(X,1);
-        Xq = nan(n,7);
-        for i = 1:n
-            Xq(i,:) = quant_clamp_x(X(i,:));
-        end
-        % derive params signatures: [xq, A_o, Qcap_big]
-        d_o_m = Xq(:,1) * 1e-3;
-        n_orf = round(Xq(:,2));
-        Ao = n_orf .* (pi * (d_o_m.^2) / 4);
-        Qcap_big = max(params.orf.CdInf .* Ao, 1e-9) .* sqrt(2 * 1.0e9 / params.rho);
-        Pmat = [Xq Ao Qcap_big];
-        % unique counts
-        uX = unique(Xq, 'rows');
-        uP = unique(Pmat, 'rows');
-        ucnt_x = size(uX,1);
-        ucnt_p = size(uP,1);
-        popsz = n;
-        % Diversity threshold and penalty share
-        thr = 10; if isstruct(optsEval) && isfield(optsEval,'uniq_thr') && ~isempty(optsEval.uniq_thr), thr = optsEval.uniq_thr; end
-        dsig = 0; if isstruct(optsEval) && isfield(optsEval,'dsig'), dsig = optsEval.dsig; end
-        share_thr = 0.5; if isstruct(optsEval) && isfield(optsEval,'pen_share_thr') && ~isempty(optsEval.pen_share_thr), share_thr = optsEval.pen_share_thr; end
-        pen_hi = 0;
-        for i = 1:n
-            key_i = jsonencode([Xq(i,:), dsig]);
-            mi = memo_store('get', key_i);
-            if ~isempty(mi)
-                share_i = Utils.getfield_default(mi,'pen',NaN);
-                if isfinite(share_i) && (share_i > share_thr)
-                    pen_hi = pen_hi + 1;
-                end
-            end
-        end
-        pen_rate = pen_hi / max(popsz,1);
-        flagLow = (ucnt_p < thr);
-        fprintf('[GA dbg/of] gen=%d | unique x=%d/%d, unique params=%d/%d | high-pen-rate=%.0f%% (thr=%.2f)%s\n', ...
-            state.Generation, ucnt_x, popsz, ucnt_p, popsz, 100*pen_rate, share_thr, tern(flagLow,'  <-- LOW DIVERSITY',''));
-    catch
-    end
 end
 
 function [f, meta] = eval_design_fast(x, scaled, params0, optsEval)
@@ -698,7 +538,6 @@ function [f, meta] = eval_design_fast(x, scaled, params0, optsEval)
     O = struct();
     if nargin >= 4 && ~isempty(optsEval), O = optsEval; end
     O.do_export = false;
-    O.export = struct('plots', true, 'ds', inf);
     O.quiet  = true;
     O.thermal_reset = 'each';
     O.order = 'natural';
@@ -856,73 +695,10 @@ function [f, meta] = eval_design_fast(x, scaled, params0, optsEval)
     catch
     end
 
-    % ---------------- Debug/pilot logging: uniqueness and penalty share ----------------
-    try
-        dbg_enabled = false;
-        if nargin >= 4 && ~isempty(optsEval) && isstruct(optsEval)
-            dbg_enabled = isfield(optsEval,'debug') && logical(optsEval.debug);
-        end
-        if dbg_enabled
-            % Build signatures:
-            %  - x_sig: quantized/clamped decision vector (x)
-            %  - p_sig: used param tuple [x, P.A_o, P.Qcap_big]
-            x_sig = mat2str(x, 6);
-            try
-                p_sig_vec = [x(1:7) P.A_o P.Qcap_big];
-            catch
-                p_sig_vec = [x(1:7) NaN NaN];
-            end
-            p_sig = mat2str(p_sig_vec, 6);
-            % Persistent state across calls
-            persistent DBG;
-            if isempty(DBG)
-                DBG = struct();
-                DBG.popsize = Utils.getfield_default(optsEval,'popsize',24);
-                DBG.count = 0;                % total eval calls since last reset
-                DBG.sigset_x = containers.Map(); % signatures (x) in current generation window
-                DBG.sigset_p = containers.Map(); % signatures (params) in current generation window
-                DBG.pen_hi = 0;               % high-penalty counter in window
-                DBG.share_thr = Utils.getfield_default(optsEval,'pen_share_thr',0.5);
-            end
-            % Start of a generation window?
-            if mod(DBG.count, DBG.popsize) == 0
-                DBG.sigset_x = containers.Map();
-                DBG.sigset_p = containers.Map();
-                DBG.pen_hi = 0;
-            end
-            % Add signature
-            if ~isKey(DBG.sigset_x, x_sig)
-                DBG.sigset_x(x_sig) = 1;
-            else
-                DBG.sigset_x(x_sig) = DBG.sigset_x(x_sig) + 1;
-            end
-            if ~isKey(DBG.sigset_p, p_sig)
-                DBG.sigset_p(p_sig) = 1;
-            else
-                DBG.sigset_p(p_sig) = DBG.sigset_p(p_sig) + 1;
-            end
-            % Penalty share (use multiplicative share lambda*pen)
-            share = lambda * pen;
-            if (share > DBG.share_thr)
-                DBG.pen_hi = DBG.pen_hi + 1;
-            end
-            DBG.count = DBG.count + 1;
-            % End of generation window -> print summary
-            if mod(DBG.count, DBG.popsize) == 0
-                genIdx = DBG.count / DBG.popsize;
-                try, uniq_x = DBG.sigset_x.Count; catch, uniq_x = numel(keys(DBG.sigset_x)); end
-                try, uniq_p = DBG.sigset_p.Count; catch, uniq_p = numel(keys(DBG.sigset_p)); end
-                pen_rate = DBG.pen_hi / max(DBG.popsize,1);
-                fprintf('[GA dbg] gen=%d | unique x=%d/%d, unique params=%d/%d | high-pen-rate=%.0f%% (thr=%.2f)\n', ...
-                    genIdx, uniq_x, DBG.popsize, uniq_p, DBG.popsize, 100*pen_rate, DBG.share_thr);
-            end
-        end
-    catch
-    end
     memo(key) = meta;
     try, memo_store('set', key, meta); catch, end
 
-end
+    end
 
 function xq = quant_clamp_x(x)
     % Apply the same quantization/clamps as in eval

--- a/3/GA/sizing_param_diff.m
+++ b/3/GA/sizing_param_diff.m
@@ -92,26 +92,9 @@ if ~isempty(old_tg) && numel(old_tg)==numel(new_tg)
 end
 if tg_changed
     T = [T; table({"toggle_gain ((n-1)x1)"}, NaN, NaN, {''}, 'VariableNames', T.Properties.VariableNames)];
-    OldS = mat2str(old_tg,3); if isempty(OldS), OldS = '[]'; end
-    NewS = mat2str(new_tg,3);
-    fprintf('\n[update] toggle_gain:\n  old: %s\n  new: %s\n', OldS, NewS);
 end
 
-% --- konsol çıktısı ---
-fprintf('\n=== PARAMETRE GÜNCELLEME ÖNERİLERİ (sadece değişenler) ===\n');
-for i=1:height(T)
-    nm = string(T.Name{i});
-    if T.Template{i}~=""
-        if contains(nm,"n_orf")
-            fprintf(' - %-18s : %g  -->  %g   (parametre.m: %s)\n', nm, T.Old(i), T.New(i), sprintf(T.Template{i}, round(T.New(i))));
-        else
-            fprintf(' - %-18s : %.6g  -->  %.6g   (parametre.m: %s)\n', nm, T.Old(i), T.New(i), sprintf(T.Template{i}, T.New(i)));
-        end
-    else
-        fprintf(' - %-18s : (vektör değişti; üstteki bloktan yeni vektörü kopyalayın)\n', nm);
-    end
-end
-fprintf('===========================================================\n\n');
+
 
 % --- CSV ---
 try


### PR DESCRIPTION
## Summary
- strip optional plotting and console logging from GA utilities
- silence parpool setup and sizing helpers to keep evaluation IO-free

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "run('Viscous/3/GA/run_ga_driver.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdce1c0fa0832890918a6f8855f22a