### PR TITLE
Clarify direct damper solver usage

### DIFF
--- a/3/GA/run_one_record_windowed.m
+++ b/3/GA/run_one_record_windowed.m
@@ -138,10 +138,8 @@ switch mode
 end
 
 %% Çözücüler
-% Sönümleyicisiz çözüm
-[x0,a_rel0] = Utils.lin_MCK(rec.t, rec.ag, params.M, params.C0, params.K);
+% Damperli çözüm doğrudan mck_with_damper_ts fonksiyonu üzerinden yürütülür.
 
-% Zaman serili sönümleyici modeli
 nMu = numel(mu_factors);
 mu_results = struct('mu_factor',cell(1,nMu));
 


### PR DESCRIPTION
## Summary
- remove leftover damperless placeholder lines in `run_one_record_windowed`
- note in Turkish that damper solution now runs directly through `mck_with_damper_ts`

## Testing
- `apt-get install -y octave` *(failed: ca-certificates-java post-install error)*
- `octave -qf --eval "run('3/GA/run_one_record_windowed.m')"` *(failed: rec undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c044573c688328a587072fc4ee5243