### PR TITLE
Add Turkish summaries and sections to GA helpers

### DIFF
--- a/3/GA/parpool_hard_reset.m
+++ b/3/GA/parpool_hard_reset.m
@@ -1,6 +1,10 @@
 function parpool_hard_reset(nWorkers)
-% Kill stale jobs, cap threads, open pool safely.
+% PARPOOL_HARD_RESET parpool'u sıfırlayıp iş parçacıklarını kısıtlar.
+% Eski işleri temizleyerek güvenli bir havuz açılışı sağlar.
+
     if nargin<1 || isempty(nWorkers), nWorkers = feature('numcores'); end
+
+    %% Havuz Temizliği
     try
         c = parcluster('Processes');
         if ~isempty(c.Jobs), delete(c.Jobs); end     % crash dump'lı işleri temizle
@@ -8,6 +12,8 @@ function parpool_hard_reset(nWorkers)
         if isempty(p) || ~isvalid(p)
             parpool(c, min(nWorkers, c.NumWorkers));
         end
+
+        %% Thread Sınırlandırma
         % oversubscription önlemleri
         pctRunOnAll maxNumCompThreads(1);
         pctRunOnAll set(0,'DefaultFigureVisible','off');

--- a/3/GA/setup.m
+++ b/3/GA/setup.m
@@ -1,16 +1,16 @@
 function oldPath = setup()
-%SETUP Add project folders to MATLAB path for testing/running.
-%   oldPath = SETUP() adds the project root and subfolders (excluding
-%   common output/hidden/example folders) to the MATLAB path and returns
-%   the previous path so you can restore it with path(oldPath) when finished.
+% SETUP proje klasörlerini MATLAB yoluna ekler.
+% Test ve çalıştırma için gerekli dizinleri dahil eder.
 
     % Project root is the folder containing this setup.m
     projectRoot = fileparts(mfilename('fullpath'));
 
+    %% Yolların Oluşturulması
     % Build a genpath and filter out unwanted folders
     rawPath = genpath(projectRoot);
     parts = strsplit(rawPath, pathsep);
 
+    %% İstenmeyen Klasörlerin Filtrelenmesi
     keep = true(size(parts));
     for i = 1:numel(parts)
         folder = parts{i};
@@ -27,6 +27,7 @@ function oldPath = setup()
 
     filteredPath = strjoin(parts(keep), pathsep);
 
+    %% Yolun Eklenmesi
     % Return old path and add the filtered one
     oldPath = path;
     addpath(filteredPath);


### PR DESCRIPTION
## Summary
- Add Turkish header comments to `parpool_hard_reset` and `setup`
- Organize code into sections for pool cleanup and thread limits
- Structure setup helper with path creation, filtering, and final addition sections

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `octave -qf --eval "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04c9be984832892414dce27e1424d