### PR TITLE
Centralize QC threshold defaults

### DIFF
--- a/3/GA/Utils.m
+++ b/3/GA/Utils.m
@@ -179,19 +179,25 @@ classdef Utils
         end
 
         %% Varsayılan QC Eşikleri
-        function thr = default_qc_thresholds(opts)
-            % Kalite kontrolü için varsayılan eşik değerlerini sağlar.
+        function thr = default_qc_thresholds(optsThr)
+            % Kalite kontrolü için varsayılan eşik değerlerini sağlar ve
+            % eksik alanları varsayılanlarla doldurur.
             % Örnek kullanım: thr = Utils.default_qc_thresholds(struct('dP95_max',40e6));
-            if nargin < 1 || isempty(opts)
-                opts = struct();
+            if nargin < 1 || isempty(optsThr)
+                optsThr = struct();
             end
             thr = struct('dP95_max',50e6, 'Qcap95_max',0.5, ...
                          'cav_pct_max',0, 'T_end_max',75, 'mu_end_min',0.5);
             fns = fieldnames(thr);
             for ii = 1:numel(fns)
-                if isfield(opts, fns{ii}) && ~isempty(opts.(fns{ii}))
-                    thr.(fns{ii}) = opts.(fns{ii});
+                if isfield(optsThr, fns{ii}) && ~isempty(optsThr.(fns{ii}))
+                    thr.(fns{ii}) = optsThr.(fns{ii});
                 end
+            end
+            % Ek alanları koru
+            extra = setdiff(fieldnames(optsThr), fns);
+            for ii = 1:numel(extra)
+                thr.(extra{ii}) = optsThr.(extra{ii});
             end
         end
     end

--- a/3/GA/run_batch_windowed.m
+++ b/3/GA/run_batch_windowed.m
@@ -221,19 +221,7 @@ summary.all_out = all_out;
 %% QC Kontrolü
 % QC eşiklerine göre sonuçların değerlendirilmesi
 % --- QC flags and reason codes for summary.csv consumers ---
-% Use thresholds from opts if provided, else defaults consistent with runners
-thr_default = struct('dP95_max',50e6,'Qcap95_max',0.5,'cav_pct_max',0,'T_end_max',75,'mu_end_min',0.5);
-if isfield(opts,'thr') && ~isempty(opts.thr)
-    thr = opts.thr;
-    fns = fieldnames(thr_default);
-    for ii=1:numel(fns)
-        if ~isfield(thr,fns{ii}) || isempty(thr.(fns{ii}))
-            thr.(fns{ii}) = thr_default.(fns{ii});
-        end
-    end
-else
-    thr = thr_default;
-end
+thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
 ok_T    = summary.table.T_end_worst   <= thr.T_end_max;
 ok_mu   = summary.table.mu_end_worst  >= thr.mu_end_min;
 ok_dP   = summary.table.dP95_worst    <= thr.dP95_max;

--- a/3/GA/run_ga_driver.m
+++ b/3/GA/run_ga_driver.m
@@ -68,15 +68,13 @@ end
         meta.s_bounds   = Utils.getfield_default(S,'s_bounds',[]);
         meta.mu_factors = Utils.getfield_default(S,'mu_factors',[0.75 1.00 1.25]);
         meta.mu_weights = Utils.getfield_default(S,'mu_weights',[0.2 0.6 0.2]);
-        thr_default = Utils.default_qc_thresholds();
-        meta.thr       = Utils.getfield_default(S,'thr', thr_default);
+        meta.thr       = Utils.default_qc_thresholds(Utils.getfield_default(S,'thr', struct()));
     else
         scaled = scaledOrSnap_local;
         params = params_local;
-        thr_default = Utils.default_qc_thresholds();
         meta = struct('IM_mode','', 'band_fac',[], 's_bounds',[], ...
                       'mu_factors',[0.75 1.00 1.25], 'mu_weights',[0.2 0.6 0.2], ...
-                      'thr', thr_default);
+                      'thr', Utils.default_qc_thresholds());
         % Auto-prepare workspace if needed (no inputs provided)
         if (isempty(scaled) || isempty(params))
             try

--- a/3/GA/run_one_record_windowed.m
+++ b/3/GA/run_one_record_windowed.m
@@ -33,21 +33,8 @@ if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
     opts.cooldown_s = max(opts.cooldown_s,0);
 end
 
-% QC thresholds (can be overridden via opts.thr)
-thr_default = struct('dP95_max',50e6, 'Qcap95_max',0.5, 'cav_pct_max',0, ...
-    'T_end_max',75, 'mu_end_min',0.5);
-if isfield(opts,'thr') && ~isempty(opts.thr)
-    thr_f = opts.thr;
-    fns = fieldnames(thr_default);
-    for ii=1:numel(fns)
-        if ~isfield(thr_f,fns{ii}) || isempty(thr_f.(fns{ii}))
-            thr_f.(fns{ii}) = thr_default.(fns{ii});
-        end
-    end
-    thr = thr_f;
-else
-    thr = thr_default;
-end
+% QC eşikleri (Utils ile varsayılanlara tamamlanır)
+thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
 
 assert(numel(opts.mu_factors)==numel(opts.mu_weights), ...
     'mu_factors and mu_weights must have same length.');

--- a/3/GA/run_policies_windowed.m
+++ b/3/GA/run_policies_windowed.m
@@ -22,18 +22,8 @@ if ~isfield(opts,'cooldown_s_list'), opts.cooldown_s_list = [60 180 300]; end
 if ~isfield(opts,'rng_seed'), opts.rng_seed = 42; end
 if ~isfield(opts,'rank_metric'), opts.rank_metric = 'E_orifice_win'; end
 
-% QC eşikleri (opts içinde saklanır)
-thr_default = struct('dP95_max',50e6,'Qcap95_max',0.5,'cav_pct_max',0,'T_end_max',75,'mu_end_min',0.5);
-if ~isfield(opts,'thr') || isempty(opts.thr)
-    opts.thr = thr_default;
-else
-    fns = fieldnames(thr_default);
-    for ii = 1:numel(fns)
-        if ~isfield(opts.thr,fns{ii}) || isempty(opts.thr.(fns{ii}))
-            opts.thr.(fns{ii}) = thr_default.(fns{ii});
-        end
-    end
-end
+% QC eşikleri (Utils ile varsayılanlara tamamlanır)
+opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
 
 % Sessizlik/çıktı bayrakları ve çıktı dizini
 quiet = isfield(opts,'quiet') && opts.quiet;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Viskoz Sönümleyici Analizleri
+## Pencereli metriklerle sismik performans değerlendirmesi
+
+Bu depo, pencere tabanlı kalite kontrol eşikleriyle viskoz sönümleyici modellerinin sismik davranışını incelemek için MATLAB betikleri içerir. `3/GA` klasörü genetik algoritma optimizasyonu ve toplu kayıt çalıştırmaları için araçlar sağlar.
+


### PR DESCRIPTION
## Summary
- Add `default_qc_thresholds` helper to fill missing QC fields with defaults
- Invoke shared helper across windowed run scripts and GA driver
- Add Turkish title and subtitle in repository README

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp(1)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04d9dcf58832894bf62253dac0a70