### PR TITLE
Centralize QC threshold defaults across GA scripts

### DIFF
--- a/3/GA/Utils.m
+++ b/3/GA/Utils.m
@@ -180,22 +180,23 @@ classdef Utils
 
         %% Varsayılan QC Eşikleri
         function thr = default_qc_thresholds(optsThr)
-            % Kalite kontrolü için varsayılan eşik değerlerini sağlar ve
-            % eksik alanları varsayılanlarla doldurur.
+            % Kalite kontrolü için varsayılan eşik değerlerini döndürür ve
+            % eksik veya boş alanları varsayılanlarla doldurur.
             % Örnek kullanım: thr = Utils.default_qc_thresholds(struct('dP95_max',40e6));
+
             if nargin < 1 || isempty(optsThr)
                 optsThr = struct();
             end
-            thr = struct('dP95_max',50e6, 'Qcap95_max',0.5, ...
-                         'cav_pct_max',0, 'T_end_max',75, 'mu_end_min',0.5);
-            fns = fieldnames(thr);
-            for ii = 1:numel(fns)
-                if isfield(optsThr, fns{ii}) && ~isempty(optsThr.(fns{ii}))
-                    thr.(fns{ii}) = optsThr.(fns{ii});
-                end
-            end
+
+            thr = struct();
+            thr.dP95_max   = Utils.getfield_default(optsThr,'dP95_max',50e6);
+            thr.Qcap95_max = Utils.getfield_default(optsThr,'Qcap95_max',0.5);
+            thr.cav_pct_max= Utils.getfield_default(optsThr,'cav_pct_max',0);
+            thr.T_end_max  = Utils.getfield_default(optsThr,'T_end_max',75);
+            thr.mu_end_min = Utils.getfield_default(optsThr,'mu_end_min',0.5);
+
             % Ek alanları koru
-            extra = setdiff(fieldnames(optsThr), fns);
+            extra = setdiff(fieldnames(optsThr), fieldnames(thr));
             for ii = 1:numel(extra)
                 thr.(extra{ii}) = optsThr.(extra{ii});
             end

--- a/3/GA/run_batch_windowed.m
+++ b/3/GA/run_batch_windowed.m
@@ -16,6 +16,7 @@ function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 if nargin < 3, opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
+opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
 
 do_export = isfield(opts,'do_export') && opts.do_export;
 if do_export
@@ -221,7 +222,7 @@ summary.all_out = all_out;
 %% QC Kontrolü
 % QC eşiklerine göre sonuçların değerlendirilmesi
 % --- QC flags and reason codes for summary.csv consumers ---
-thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+thr = opts.thr;
 ok_T    = summary.table.T_end_worst   <= thr.T_end_max;
 ok_mu   = summary.table.mu_end_worst  >= thr.mu_end_min;
 ok_dP   = summary.table.dP95_worst    <= thr.dP95_max;

--- a/3/GA/run_ga_driver.m
+++ b/3/GA/run_ga_driver.m
@@ -127,7 +127,11 @@ end
     optsEval.thermal_reset = 'each';
     if ~isfield(optsEval,'mu_factors'), optsEval.mu_factors = meta.mu_factors; end
     if ~isfield(optsEval,'mu_weights'), optsEval.mu_weights = meta.mu_weights; end
-    if ~isfield(optsEval,'thr'),        optsEval.thr        = meta.thr; end
+    if ~isfield(optsEval,'thr')
+        optsEval.thr = meta.thr;
+    else
+        optsEval.thr = Utils.default_qc_thresholds(optsEval.thr);
+    end
     %% GA Kurulumu
     % GA amaç fonksiyonu ve optimizasyon seçeneklerini hazırla.
     if nargin < 4 || isempty(optsGA), optsGA = struct; end

--- a/3/GA/run_one_record_windowed.m
+++ b/3/GA/run_one_record_windowed.m
@@ -33,8 +33,9 @@ if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
     opts.cooldown_s = max(opts.cooldown_s,0);
 end
 
-% QC eşikleri (Utils ile varsayılanlara tamamlanır)
-thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+% QC eşikleri (eksik alanlar varsayılanlarla doldurulur)
+opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+thr = opts.thr;
 
 assert(numel(opts.mu_factors)==numel(opts.mu_weights), ...
     'mu_factors and mu_weights must have same length.');


### PR DESCRIPTION
## Summary
- Add `default_qc_thresholds` helper in `Utils` to supply and merge quality-control thresholds.
- Initialize and reuse QC thresholds via `Utils.default_qc_thresholds` in GA driver and windowed runners.

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c058172f048328bc8e5b1df0b57151