### PR TITLE
feat: add safe file writing helper

### DIFF
--- a/3/GA/make_sizing_case.m
+++ b/3/GA/make_sizing_case.m
@@ -345,7 +345,7 @@ function [updates, T] = sizing_param_diff(P_old, P_sized, gainsPF, sizing)
 
     % --- CSV yazımı -----------------------------------------------------
     outdir = fullfile('out'); if ~exist(outdir,'dir'), mkdir(outdir); end
-    safe_write(T, fullfile(outdir,'sizing_updates.csv'));
+    safe_write(T, fullfile(outdir,'sizing_updates.csv'), @writetable);
 
     % --- parametre.m'e yapıştırmalık satırlar --------------------------
     updates = struct(); updates.lines = {};
@@ -361,15 +361,11 @@ function [updates, T] = sizing_param_diff(P_old, P_sized, gainsPF, sizing)
     updates.toggle_gain_vec = new_tg;
 end
 
-function safe_write(data, filepath)
+function safe_write(obj, filepath, writeFcn)
     try
-        [~,~,ext] = fileparts(filepath);
-        if strcmpi(ext,'.json')
-            Utils.writejson(data, filepath);
-        else
-            writetable(data, filepath);
-        end
-    catch
+        writeFcn(obj, filepath);
+    catch ME
+        warning('Yazma hatası (%s): %s', filepath, ME.message);
     end
 end
 


### PR DESCRIPTION
## Summary
- localize result export sections to "Meta", "Özetler", "Kayıt Bazlı"
- add `safe_write` utility wrapping file writes with warnings on error
- apply new helper across GA driver and sizing scripts

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05a0c704883288600745256119ab9