### PR TITLE
Standardize QC threshold handling in GA scripts

### DIFF
--- a/3/GA/run_batch_windowed.m
+++ b/3/GA/run_batch_windowed.m
@@ -16,7 +16,8 @@ function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 if nargin < 3, opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
-opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+if ~isfield(opts,'thr'), opts.thr = struct(); end
+opts.thr = Utils.default_qc_thresholds(opts.thr);
 
 do_export = isfield(opts,'do_export') && opts.do_export;
 if do_export

--- a/3/GA/run_ga_driver.m
+++ b/3/GA/run_ga_driver.m
@@ -68,13 +68,14 @@ end
         meta.s_bounds   = Utils.getfield_default(S,'s_bounds',[]);
         meta.mu_factors = Utils.getfield_default(S,'mu_factors',[0.75 1.00 1.25]);
         meta.mu_weights = Utils.getfield_default(S,'mu_weights',[0.2 0.6 0.2]);
-        meta.thr       = Utils.default_qc_thresholds(Utils.getfield_default(S,'thr', struct()));
+        if ~isfield(S,'thr'), S.thr = struct(); end
+        meta.thr       = Utils.default_qc_thresholds(S.thr);
     else
         scaled = scaledOrSnap_local;
         params = params_local;
         meta = struct('IM_mode','', 'band_fac',[], 's_bounds',[], ...
                       'mu_factors',[0.75 1.00 1.25], 'mu_weights',[0.2 0.6 0.2], ...
-                      'thr', Utils.default_qc_thresholds());
+                      'thr', Utils.default_qc_thresholds(struct()));
         % Auto-prepare workspace if needed (no inputs provided)
         if (isempty(scaled) || isempty(params))
             try
@@ -127,11 +128,8 @@ end
     optsEval.thermal_reset = 'each';
     if ~isfield(optsEval,'mu_factors'), optsEval.mu_factors = meta.mu_factors; end
     if ~isfield(optsEval,'mu_weights'), optsEval.mu_weights = meta.mu_weights; end
-    if ~isfield(optsEval,'thr')
-        optsEval.thr = meta.thr;
-    else
-        optsEval.thr = Utils.default_qc_thresholds(optsEval.thr);
-    end
+    if ~isfield(optsEval,'thr'), optsEval.thr = meta.thr; end
+    optsEval.thr = Utils.default_qc_thresholds(optsEval.thr);
     %% GA Kurulumu
     % GA amaç fonksiyonu ve optimizasyon seçeneklerini hazırla.
     if nargin < 4 || isempty(optsGA), optsGA = struct; end

--- a/3/GA/run_one_record_windowed.m
+++ b/3/GA/run_one_record_windowed.m
@@ -34,7 +34,8 @@ if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
 end
 
 % QC eşikleri (eksik alanlar varsayılanlarla doldurulur)
-opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+if ~isfield(opts,'thr'), opts.thr = struct(); end
+opts.thr = Utils.default_qc_thresholds(opts.thr);
 thr = opts.thr;
 
 assert(numel(opts.mu_factors)==numel(opts.mu_weights), ...

--- a/3/GA/run_policies_windowed.m
+++ b/3/GA/run_policies_windowed.m
@@ -23,7 +23,8 @@ if ~isfield(opts,'rng_seed'), opts.rng_seed = 42; end
 if ~isfield(opts,'rank_metric'), opts.rank_metric = 'E_orifice_win'; end
 
 % QC eşikleri (Utils ile varsayılanlara tamamlanır)
-opts.thr = Utils.default_qc_thresholds(Utils.getfield_default(opts,'thr', struct()));
+if ~isfield(opts,'thr'), opts.thr = struct(); end
+opts.thr = Utils.default_qc_thresholds(opts.thr);
 
 % Sessizlik/çıktı bayrakları ve çıktı dizini
 quiet = isfield(opts,'quiet') && opts.quiet;


### PR DESCRIPTION
## Summary
- Initialize quality-control thresholds via `Utils.default_qc_thresholds(opts.thr)` across GA utilities
- Keep batch processing script organized with MATLAB `%%` sections for inputs, record loop, summary, and QC checks

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05cd93b4483289fe52a0806ac5328