### PR TITLE
Add try_warn helper and simplify GA driver error handling

### DIFF
--- a/3/GA/Utils.m
+++ b/3/GA/Utils.m
@@ -148,6 +148,20 @@ classdef Utils
             if c, s=a; else, s=b; end
         end
 
+        %% Güvenli Çalıştırma ve Uyarı
+        function varargout = try_warn(funcHandle, msgPrefix)
+            %TRY_WARN Hata durumunda uyarı vererek fonksiyonu çalıştırır.
+            %   varargout = Utils.try_warn(@() func(), 'prefix')
+            try
+                [varargout{1:nargout}] = funcHandle();
+            catch ME
+                warning('%s: %s', msgPrefix, ME.message);
+                for k = 1:nargout
+                    varargout{k} = [];
+                end
+            end
+        end
+
         %% Başlangıç Popülasyon Izgarası
         function P = initial_pop_grid(lb, ub, N, steps)
             %INITIAL_POP_GRID Değişken ızgaralarına hizalanmış bir başlangıç popülasyonu oluşturur.


### PR DESCRIPTION
## Summary
- add Utils.try_warn helper to run functions with warnings on failure
- refactor run_ga_driver to use Utils.try_warn instead of basic try/catch/warning blocks

## Testing
- `octave -qf --eval "printf('a\\nb')"` *(fails: command not found)*
- `matlab -batch "exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c07ced67948328abd64a1d984ff36b