### PR TITLE
Refactor GA driver for expanded damper design variables

### DIFF
--- a/3/GA/parametreler.m
+++ b/3/GA/parametreler.m
@@ -42,7 +42,7 @@ T1 = 2*pi/w(1);
 %% --- 2) Damper geometrisi ve malzeme ---
 Dp     = 0.125;     % Piston çapı [m]
 Lgap   = 0.055;     % Dış gövde/piston aralığı [m]
-d_o    = 1.5e-3;    % Orifis çapı [m]
+d_o    = 3.0e-3;    % Orifis çapı [m]
 Lori   = 0.10;      % Orifis uzunluğu [m]
 mu_ref = 0.9;       % Referans viskozite [Pa·s]
 
@@ -84,10 +84,18 @@ orf.bounds.Cd0   = [0.50 0.70];      % Cd0 için sınırlar
 orf.bounds.CdInf = [0.75 0.95];      % CdInf için sınırlar
 orf.bounds.p_exp = [0.80 1.40];      % p_exp için sınırlar
 
-% Ek GA sınırları
-bounds.Lori   = [0.06 0.14];         % Orifis uzunluğu [m]
-bounds.c_lam0 = [2e7 4e7];          % Laminer sönüm [N·s/m]
+% GA sınırları (karar değişkenleri)
+bounds.d_o_mm    = [2.80 3.60];      % Orifis çapı [mm]
+bounds.n_orf     = [5 8];            % Orifis adedi [-]
+bounds.PF_tau    = [0.95 1.10];      % PF zaman sabiti [s]
+bounds.PF_gain   = [0.78 0.90];      % PF kazancı [-]
+bounds.Lori_mm   = [60 140];         % Orifis uzunluğu [mm]
 bounds.hA_W_perK = [200 800];       % Konvektif ısı kaybı [W/K]
+bounds.Dp_mm     = [100 160];        % Piston çapı [mm]
+bounds.d_w_mm    = [8 16];           % Yay teli çapı [mm]
+bounds.D_m_mm    = [60 100];         % Yay orta çapı [mm]
+bounds.n_turn    = [6 12];           % Yay tur sayısı [-]
+bounds.mu_ref    = [0.60 1.20];      % Referans viskozite [Pa·s]
 
 % Akış satürasyonu (sayısal kararlılık için)
 Qcap_big = max(orf.CdInf*A_o, 1e-9) * sqrt(2*1.0e9/rho);
@@ -122,8 +130,8 @@ c_lam_min      = max(c_lam_min_abs, c_lam_min_frac*c_lam0);
 % Basınç-kuvvet filtresi (PF) ayarları
 cfg = struct();
 cfg.PF.mode      = 'ramp';
-cfg.PF.tau       = 0.05;
-cfg.PF.gain      = 1.0;
+cfg.PF.tau       = 1.0;
+cfg.PF.gain      = 0.85;
 cfg.PF.t_on      = 0;
 cfg.PF.auto_t_on = true;
 cfg.on.pressure_force     = true;

--- a/3/parametreler.m
+++ b/3/parametreler.m
@@ -42,7 +42,7 @@ T1 = 2*pi/w(1);
 %% --- 2) Damper geometrisi ve malzeme ---
 Dp     = 0.125;     % Piston çapı [m]
 Lgap   = 0.055;     % Dış gövde/piston aralığı [m]
-d_o    = 1.5e-3;    % Orifis çapı [m]
+d_o    = 3.0e-3;    % Orifis çapı [m]
 Lori   = 0.10;      % Orifis uzunluğu [m]
 mu_ref = 0.9;       % Referans viskozite [Pa·s]
 
@@ -112,8 +112,8 @@ c_lam_min      = max(c_lam_min_abs, c_lam_min_frac*c_lam0);
 % Basınç-kuvvet filtresi (PF) ayarları
 cfg = struct();
 cfg.PF.mode      = 'ramp';
-cfg.PF.tau       = 0.05;
-cfg.PF.gain      = 1.0;
+cfg.PF.tau       = 1.0;
+cfg.PF.gain      = 0.85;
 cfg.PF.t_on      = 0;
 cfg.PF.auto_t_on = true;
 cfg.on.pressure_force     = true;

--- a/3/readme.md
+++ b/3/readme.md
@@ -68,8 +68,8 @@ Orifis ve termal etkiler **açık** iken damper modelini çalıştırarak her ka
 - **Hafif Değerlendirme:** Her değerlendirmede çizim/CSV/snapshot/diary yazımı yapılmaz; tekrar eden tasarımlar önbellekten gelir.
 
 **Karar Vektörü ve Izgaralar**
-- **x:** `[d_o_mm, n_orf, g_lo, g_mid, g_hi, PF_tau, PF_gain]`
-- **Adımlar:** `d_o_mm:0.1`, `n_orf:integer(2..6)`, `g_*:0.05`, `PF_tau:0.1 s`, `PF_gain:0.02`.
+- **x:** `[d_o_mm, n_orf, PF_tau, PF_gain, Cd0, CdInf, p_exp, Lori_mm, hA_W_perK, Dp_mm, d_w_mm, D_m_mm, n_turn, mu_ref]`
+- **Adımlar:** `d_o_mm:0.1`, `n_orf:integer`, `PF_tau:0.01`, `PF_gain:0.02`, `Cd0/CdInf:0.01`, `p_exp:0.05`, `Lori_mm:1`, `hA_W_perK:25`, `Dp_mm:1`, `d_w_mm:0.5`, `D_m_mm:5`, `n_turn:integer`, `mu_ref:0.05`.
 
 **Yeni Dosyalar**
 - `quantize_step.m:1`: Bir skaler/vektörü `step*round(x/step)` ile ızgaraya oturtur.


### PR DESCRIPTION
## Summary
- expand GA decision vector to 14 damper parameters and update bounds/clamping
- extend parameter decoding to recompute hydraulic constants and spring stiffness
- document new GA bounds and defaults

## Testing
- `octave -qf --eval "try, run('3/GA/run_ga_driver.m'); catch ME, disp(ME.message); end;"` *(command failed: octave not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c090607ecc83288c72fb930b3a8855