### PR TITLE
Add story force target tracking and penalty

### DIFF
--- a/3/GA/export_results.m
+++ b/3/GA/export_results.m
@@ -121,6 +121,9 @@ for k = 1:numel(all_out)
         if isfield(out,'PF_mode'),       mstruct.PF_mode = out.PF_mode; end
         if isfield(out,'PF_auto_t_on'),  mstruct.PF_auto_t_on = out.PF_auto_t_on; end
         mstruct.mu_mode = mu_mode; mstruct.mu_used = mu_used;
+        if isfield(out,'F_story_target_pk'), mstruct.F_story_target = out.F_story_target_pk; end
+        if isfield(out,'F_story_actual_pk'), mstruct.F_story = out.F_story_actual_pk; end
+        if isfield(out,'F_story_penalty'), mstruct.F_story_penalty = out.F_story_penalty; end
         % Yeni parametreleri isteğe bağlı olarak metriklere ekle
         param_fields = {'Dp_mm','d_w_mm','D_m_mm','n_turn','mu_ref'};
         for ii = 1:numel(param_fields)

--- a/3/GA/run_batch_windowed.m
+++ b/3/GA/run_batch_windowed.m
@@ -112,6 +112,10 @@ T_end      = zeros(n,1);
 mu_end     = zeros(n,1);
 clamp_hits = zeros(n,1);
 
+F_story_target_pk = nan(n,1);
+F_story_actual_pk = nan(n,1);
+F_story_penalty   = nan(n,1);
+
 Dp_mm_col   = repmat(Utils.getfield_default(params,'Dp_mm',NaN), n,1);
 mu_ref_col  = repmat(Utils.getfield_default(params,'mu_ref',NaN), n,1);
 
@@ -123,7 +127,13 @@ worstIDR = -inf; worstIDR_name = ''; worstIDR_mu = NaN;
 prev_diag = [];
 for k = 1:n
     rec = scaled(k);
-    out = run_one_record_windowed(rec, params, opts, prev_diag);
+    if isfield(opts,'F_story_target')
+        opts_i = opts;
+        opts_i.F_story_target = opts.F_story_target{k};
+    else
+        opts_i = opts;
+    end
+    out = run_one_record_windowed(rec, params, opts_i, prev_diag);
     prev_diag = out.diag;
     all_out{k} = out; %#ok<AGROW>
 
@@ -144,6 +154,10 @@ for k = 1:n
     T_end(k)      = out.T_end;
     mu_end(k)     = out.mu_end;
     clamp_hits(k) = out.clamp_hits;
+
+    F_story_target_pk(k) = Utils.getfield_default(out,'F_story_target_pk',NaN);
+    F_story_actual_pk(k) = Utils.getfield_default(out,'F_story_actual_pk',NaN);
+    F_story_penalty(k)   = Utils.getfield_default(out,'F_story_penalty',NaN);
 
     m_nom = out.metr;
     PFA_nom(k)    = m_nom.PFA_top;
@@ -230,14 +244,14 @@ summary.table = table(names, scale, SaT1, t5, t95, coverage, rank_score, policy_
     PFA_worst, IDR_worst, dP95_worst, dP_orf_q50_worst, Qcap95_worst, Q_q95_worst, Q_q50_worst, PF_p95_worst, ...
     cav_pct_worst, x10_max_D_worst, a10abs_max_D_worst, E_orifice_sum, E_struct_sum, E_ratio, ...
     which_mu_PFA, which_mu_IDR, T_end_worst, mu_end_worst, qc_all_mu, ...
-    T_start, T_end, mu_end, clamp_hits, Dp_mm_col, mu_ref_col, ...
+    T_start, T_end, mu_end, clamp_hits, F_story_target_pk, F_story_actual_pk, F_story_penalty, Dp_mm_col, mu_ref_col, ...
     'VariableNames', {'name','scale','SaT1','t5','t95','coverage','rank_score','policy','order','cooldown_s', ...
     'PFA_nom','IDR_nom','dP95_nom','Qcap95_nom','cav_nom','zeta1_hot','z2_over_z1_hot','P_mech','Re_max', ...
     'PFA_w','IDR_w','dP95_w','Qcap95_w','Q_q95_w','Q_q50_w','dP50_w', ...
     'PFA_worst','IDR_worst','dP95_worst','dP_orf_q50_worst','Qcap95_worst','Q_q95_worst','Q_q50_worst','PF_p95_worst', ...
     'cav_pct_worst','x10_max_D_worst','a10abs_max_D_worst','E_orifice_sum','E_struct_sum','E_ratio', ...
     'which_mu_PFA','which_mu_IDR','T_end_worst','mu_end_worst','qc_all_mu', ...
-    'T_start','T_end','mu_end','clamp_hits','Dp_mm','mu_ref'});
+    'T_start','T_end','mu_end','clamp_hits','F_story_target','F_story','F_story_penalty','Dp_mm','mu_ref'});
 
 % Tüketicilerle uyumluluk için takma adlar
 summary.table.T_oil_end_worst = summary.table.T_end_worst;


### PR DESCRIPTION
## Summary
- capture baseline story force profiles via toggle gain run
- penalize deviations from target story forces during GA evaluation
- export target and achieved story-force metrics in results

## Testing
- `octave --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c144c22f988328aef0fc7fbd610488