### PR TITLE
Ensure orifice and thermal flags default to true

### DIFF
--- a/3/GA/run_ga_driver.m
+++ b/3/GA/run_ga_driver.m
@@ -117,6 +117,8 @@ Utils.try_warn(@() parpool_hard_reset(16), '[run_ga_driver] parpool başlatılam
     if ~isfield(optsEval,'mu_weights'), optsEval.mu_weights = meta.mu_weights; end
     if ~isfield(optsEval,'thr'), optsEval.thr = meta.thr; end
     optsEval.thr = Utils.default_qc_thresholds(optsEval.thr);
+    if ~isfield(optsEval,'use_orifice'), optsEval.use_orifice = true; end
+    if ~isfield(optsEval,'use_thermal'), optsEval.use_thermal = true; end
     % --- Hedef kat kuvvetlerini belirlemek için toggle_gain ile ön çalışma ---
     opts_target = optsEval;
     [summary_target, all_out_target] = run_batch_windowed(scaled, params, opts_target);

--- a/3/GA/run_one_record_windowed.m
+++ b/3/GA/run_one_record_windowed.m
@@ -25,6 +25,8 @@ if nargin < 4, prev_diag = []; end
 if nargin < 3 || isempty(opts), opts = struct(); end
 if ~isfield(opts,'mu_factors'), opts.mu_factors = [0.75 1.00 1.25]; end
 if ~isfield(opts,'mu_weights'), opts.mu_weights = [0.2 0.6 0.2]; end
+if ~isfield(opts,'use_orifice'), opts.use_orifice = true; end
+if ~isfield(opts,'use_thermal'), opts.use_thermal = true; end
 
 % Türetilmiş damper sabitlerini güncelle
 params = Utils.recompute_damper_params(params);


### PR DESCRIPTION
## Summary
- Add default flags for using orifice flow and thermal modeling in record analysis.
- Set corresponding flags in GA evaluation options so both target and GA runs include them.

## Testing
- ⚠️ `octave -qf --eval "disp('OK')"` (command not found)
- ⚠️ `matlab -batch "disp('OK')"` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c148fea5e8832897d937728764fa68