### PR TITLE
Add parameter grid script and array-based parameters

### DIFF
--- a/toggle/parametreler.m
+++ b/toggle/parametreler.m
@@ -96,8 +96,8 @@ thermal.dT_max    = 80;              % Maksimum izin verilen ΔT [K]
 
 % Ek kütle/kapasite verileri
 steel_to_oil_mass_ratio = 1.5;       % Çelik/yağ kütle oranı
-n_dampers_per_story    = 1;          % Kat başına damper adedi (skaler veya (n-1)x1 vektör)
-toggle_gain            = 1.6;        % Toggle kazancı (skaler veya (n-1)x1 vektör)
+n_dampers_per_story    = [1];        % Kat başına damper adedi (tarama için dizi)
+toggle_gain            = [1.6];      % Toggle kazancı (tarama için dizi)
 story_mask             = ones(n-1,1);% Kat maskesi; 1=aktif, 0=damper yok
 cp_oil   = 1800;                     % Yağın özgül ısısı [J/(kg·K)]
 cp_steel = 500;                      % Çeliğin özgül ısısı [J/(kg·K)]

--- a/toggle/run_param_grid.m
+++ b/toggle/run_param_grid.m
@@ -1,0 +1,54 @@
+%% Parametre ızgarası üzerinde analiz çalıştır
+% Bu betik parametreler.m içindeki tarama dizilerini alır ve
+% tüm kombinasyonlar için run_one_record_windowed fonksiyonunu çağırır.
+
+% 1) Parametreleri yükle
+parametreler; %#ok<*NASGU>
+
+% Tarama yapılacak parametre dizileri
+ndps_vals = n_dampers_per_story(:);
+gain_vals = toggle_gain(:);
+
+% 2) Tüm kombinasyonları üret
+[NDPS, GAIN] = ndgrid(ndps_vals, gain_vals);
+comb = [NDPS(:), GAIN(:)];
+
+% 3) Yer hareketi kaydını yükle (hızlı olması için ilk kayıt)
+[~, scaled] = load_ground_motions(T1);
+rec = scaled(1);
+
+% 4) Temel parametre yapısı (tarama dışındaki parametreler)
+base_params = struct('M',M,'C0',C0,'K',K,'k_sd',k_sd,'c_lam0',c_lam0, ...
+    'orf',orf,'rho',rho,'Ap',Ap,'A_o',A_o,'Qcap_big',Qcap_big,'mu_ref',mu_ref, ...
+    'thermal',thermal,'T0_C',T0_C,'T_ref_C',T_ref_C,'b_mu',b_mu, ...
+    'c_lam_min',c_lam_min,'c_lam_cap',c_lam_cap,'Lgap',Lgap, ...
+    'cp_oil',cp_oil,'cp_steel',cp_steel,'steel_to_oil_mass_ratio',steel_to_oil_mass_ratio, ...
+    'story_mask',story_mask,'resFactor',resFactor,'cfg',cfg,'story_height',story_height);
+
+% Çıktı dosyası
+outdir = 'out'; if ~exist(outdir,'dir'), mkdir(outdir); end
+outfile = fullfile(outdir, 'param_grid_results.csv');
+if exist(outfile,'file'), delete(outfile); end
+all_results = table();
+
+% 5) Parametre kombinasyonları üzerinde döngü
+opts = struct('use_orifice', true, 'use_thermal', true);
+for i = 1:size(comb,1)
+    params = base_params;
+    params.n_dampers_per_story = comb(i,1);
+    params.toggle_gain = comb(i,2);
+
+    out = run_one_record_windowed(rec, [], params, opts);
+    row = table(params.n_dampers_per_story, params.toggle_gain, ...
+        out.metr.PFA_top, out.metr.IDR_max, out.metr.dP_orf_q95, ...
+        'VariableNames', {'n_dampers_per_story','toggle_gain','PFA_top','IDR_max','dP_orf_q95'});
+    all_results = [all_results; row]; %#ok<AGROW>
+
+    if i == 1
+        writetable(row, outfile);
+    else
+        writetable(row, outfile, 'WriteMode', 'append', 'WriteVariableNames', false);
+    end
+end
+
+disp(all_results);


### PR DESCRIPTION
## Summary
- Represent damper count and toggle gain as arrays in `parametreler.m` for parameter sweeps
- Add `run_param_grid.m` to generate nd-grid combinations and run `run_one_record_windowed` for each set
- Write each run's metrics and parameter values to `out/param_grid_results.csv`

## Testing
- ❌ `octave -qf --eval "cd('toggle'); run('run_param_grid.m');"` (missing `griddedInterpolant` in Octave)


------
https://chatgpt.com/codex/tasks/task_e_68c19a1224148328871e3dc85d04bd8b