### PR TITLE
Generalize parameter sweep

### DIFF
--- a/toggle/parametreler.m
+++ b/toggle/parametreler.m
@@ -42,7 +42,7 @@ T1 = 2*pi/w(1);
 %% --- 2) Damper geometrisi ve malzeme ---
 Dp     = 0.125;     % Piston çapı [m]
 Lgap   = 0.055;     % Dış gövde/piston aralığı [m]
-d_o    = 1.5e-3;    % Orifis çapı [m]
+d_o    = [0.75e-3 1.5e-3 3e-3]; % Orifis çapı [m] (tarama için dizi)
 Lori   = 0.10;      % Orifis uzunluğu [m]
 mu_ref = 0.9;       % Referans viskozite [Pa·s]
 
@@ -60,12 +60,12 @@ k_s   = Ebody*Ap/Lgap;                % Gövde sertliği [N/m]
 k_hyd = 1/(1/k_h + 1/k_s);            % Seri bağlanmış eşdeğer
 k_p   = Gsh*d_w^4/(8*n_turn*D_m^3);   % Yay (körük) sertliği [N/m]
 k_sd  = k_hyd + k_p;                  % Toplam seri damper sertliği [N/m]
-c_lam0 = 12*mu_ref*Lori*Ap^2/d_o^4;   % Laminer eşdeğer sönüm (T0)
+c_lam0 = 12*mu_ref*Lori*Ap^2 ./ d_o.^4;   % Laminer eşdeğer sönüm (T0)
 
 %% --- 3) Orifis ve termal parametreleri ---
 rho   = 850;       % Yağ yoğunluğu [kg/m^3]
 n_orf = 6;         % Kat başına orifis sayısı
-A_o   = n_orf * (pi*d_o^2/4);     % Toplam orifis alanı [m^2]
+A_o   = n_orf * (pi*d_o.^2/4);     % Toplam orifis alanı [m^2]
 
 % Orifis katsayıları
 orf = struct();
@@ -76,7 +76,7 @@ orf.p_exp = 1.1;                     % Geçiş eğrisinin eğimi
 orf.p_amb = 1.0e5;                   % Ortam basıncı [Pa]
 orf.p_cav_eff = 2.0e3;               % Etkin kavitasyon eşiği [Pa]
 orf.cav_sf    = 0.90;                % Kavitasyon emniyet katsayısı
-orf.d_o   = d_o;                     % Re düzeltmesi için çap [m]
+orf.d_o   = d_o(:);                  % Re düzeltmesi için çap [m]
 orf.veps  = 0.10;                    % Düşük hız yumuşatma [m/s]
 
 % Akış satürasyonu (sayısal kararlılık için)
@@ -96,8 +96,8 @@ thermal.dT_max    = 80;              % Maksimum izin verilen ΔT [K]
 
 % Ek kütle/kapasite verileri
 steel_to_oil_mass_ratio = 1.5;       % Çelik/yağ kütle oranı
-n_dampers_per_story    = 1;          % Kat başına damper adedi (skaler veya (n-1)x1 vektör)
-toggle_gain            = 1.6;        % Toggle kazancı (skaler veya (n-1)x1 vektör)
+n_dampers_per_story    = [1 2 3];    % Kat başına damper adedi (tarama için dizi)
+toggle_gain            = [1.4 1.6 1.8];      % Toggle kazancı (tarama için dizi)
 story_mask             = ones(n-1,1);% Kat maskesi; 1=aktif, 0=damper yok
 cp_oil   = 1800;                     % Yağın özgül ısısı [J/(kg·K)]
 cp_steel = 500;                      % Çeliğin özgül ısısı [J/(kg·K)]
@@ -118,3 +118,6 @@ cfg.PF.t_on      = 0;
 cfg.PF.auto_t_on = true;
 cfg.on.pressure_force     = true;
 cfg.on.pf_resistive_only = true;  % sadece rezistif (viskoz+orifis) bileşeni filtrele
+
+% Tarama yapılacak parametrelerin isim listesi
+sweep_vars = {'n_dampers_per_story','toggle_gain','d_o'};

--- a/toggle/run_param_grid.m
+++ b/toggle/run_param_grid.m
@@ -1,0 +1,70 @@
+%% Parametre ızgarası üzerinde analiz çalıştır
+% Bu betik parametreler.m içindeki tarama dizilerini alır ve
+% tüm kombinasyonlar için run_one_record_windowed fonksiyonunu çağırır.
+
+% 1) Parametreleri yükle
+parametreler; %#ok<*NASGU>
+
+% Tarama yapılacak parametre dizilerini oku
+val_cells = cell(size(sweep_vars));
+for ii = 1:numel(sweep_vars)
+    val_cells{ii} = eval(sweep_vars{ii})(:);
+end
+
+% 2) Tüm kombinasyonları üret
+[grids{1:numel(val_cells)}] = ndgrid(val_cells{:});
+n_comb = numel(grids{1});
+
+% 3) Yer hareketi kaydını yükle (hızlı olması için ilk kayıt)
+[~, scaled] = load_ground_motions(T1);
+rec = scaled(1);
+
+% 4) Temel parametre yapısı (tarama dışındaki parametreler)
+base_orf = orf; base_orf.d_o = orf.d_o(1);
+base_params = struct('M',M,'C0',C0,'K',K,'k_sd',k_sd,'c_lam0',c_lam0(1), ...
+    'orf',base_orf,'rho',rho,'Ap',Ap,'A_o',A_o(1),'Qcap_big',Qcap_big(1),'mu_ref',mu_ref, ...
+    'thermal',thermal,'T0_C',T0_C,'T_ref_C',T_ref_C,'b_mu',b_mu, ...
+    'c_lam_min',c_lam_min(1),'c_lam_cap',c_lam_cap,'Lgap',Lgap, ...
+    'cp_oil',cp_oil,'cp_steel',cp_steel,'steel_to_oil_mass_ratio',steel_to_oil_mass_ratio, ...
+    'story_mask',story_mask,'resFactor',resFactor,'cfg',cfg,'story_height',story_height,'d_o',d_o(1));
+
+% Çıktı dosyası
+outdir = 'out'; if ~exist(outdir,'dir'), mkdir(outdir); end
+outfile = fullfile(outdir, 'param_grid_results.csv');
+if exist(outfile,'file'), delete(outfile); end
+all_results = table();
+
+% 5) Parametre kombinasyonları üzerinde döngü
+opts = struct('use_orifice', true, 'use_thermal', true);
+for i = 1:n_comb
+    params = base_params;
+    row_vals = zeros(1, numel(sweep_vars));
+    for j = 1:numel(sweep_vars)
+        val = grids{j}(i);
+        field = sweep_vars{j};
+        params.(field) = val;
+        row_vals(j) = val;
+    end
+
+    if isfield(params, 'd_o')
+        d_o_val = params.d_o;
+        params.A_o = n_orf * (pi*d_o_val^2/4);
+        params.c_lam0 = 12*mu_ref*Lori*Ap^2 / d_o_val^4;
+        params.orf.d_o = d_o_val;
+        params.Qcap_big = max(params.orf.CdInf*params.A_o, 1e-9) * sqrt(2*1.0e9/rho);
+        params.c_lam_min = max(c_lam_min_abs, c_lam_min_frac*params.c_lam0);
+    end
+
+    out = run_one_record_windowed(rec, [], params, opts);
+    row = array2table([row_vals, out.metr.PFA_top, out.metr.IDR_max, out.metr.dP_orf_q95], ...
+        'VariableNames', [sweep_vars, {'PFA_top','IDR_max','dP_orf_q95'}]);
+    all_results = [all_results; row]; %#ok<AGROW>
+
+    if i == 1
+        writetable(row, outfile);
+    else
+        writetable(row, outfile, 'WriteMode', 'append', 'WriteVariableNames', false);
+    end
+end
+
+disp(all_results);


### PR DESCRIPTION
## Summary
- Allow orifice diameter, damper count, and toggle gain to be defined as arrays for sweeps
- Add `sweep_vars` list and update `run_param_grid.m` to iterate over arbitrary parameter combinations
- Recompute dependent quantities when sweeping `d_o`

## Testing
- ❌ `octave -qf --eval "cd('toggle'); run('run_param_grid.m');"` (missing `griddedInterpolant` in Octave)


------
https://chatgpt.com/codex/tasks/task_e_68c19a1224148328871e3dc85d04bd8b