### PR TITLE
Extend toggle param grid sweep and metrics

### DIFF
--- a/toggle/parametreler.m
+++ b/toggle/parametreler.m
@@ -41,17 +41,25 @@ T1 = 2*pi/w(1);
 
 %% --- 2) Damper geometrisi ve malzeme ---
 Dp     = 0.125;     % Piston çapı [m]
+Dp_vals   = Dp;     % Tarama aralığı
 Lgap   = 0.055;     % Dış gövde/piston aralığı [m]
+Lgap_vals = Lgap;   % Tarama aralığı
 d_o    = 1.5e-3;    % Orifis çapı [m]
+d_o_vals = d_o;     % Tarama aralığı
 Lori   = 0.10;      % Orifis uzunluğu [m]
+Lori_vals = Lori;   % Tarama aralığı
 mu_ref = 0.9;       % Referans viskozite [Pa·s]
+mu_ref_vals = mu_ref; % Tarama aralığı
 
 Kd     = 1.6e9;     % Hidrolik sertlik katsayısı [N/m]
 Ebody  = 2.1e11;    % Gövde elastisite modülü [Pa]
 Gsh    = 79e9;      % Körük kayma modülü [Pa]
 d_w    = 12e-3;     % Yay teli çapı [m]
+d_w_vals = d_w;     % Tarama aralığı
 D_m    = 80e-3;     % Yay orta çapı [m]
+D_m_vals = D_m;     % Tarama aralığı
 n_turn = 8;         % Yay tur sayısı [-]
+n_turn_vals = n_turn; % Tarama aralığı
 
 % Türetilen sabitler (lineer eşdeğer)
 Ap    = pi*Dp^2/4;                    % Piston alanı [m^2]
@@ -64,18 +72,27 @@ c_lam0 = 12*mu_ref*Lori*Ap^2/d_o^4;   % Laminer eşdeğer sönüm (T0)
 
 %% --- 3) Orifis ve termal parametreleri ---
 rho   = 850;       % Yağ yoğunluğu [kg/m^3]
+rho_vals = rho;    % Tarama aralığı
 n_orf = 6;         % Kat başına orifis sayısı
+n_orf_vals = n_orf; % Tarama aralığı
 A_o   = n_orf * (pi*d_o^2/4);     % Toplam orifis alanı [m^2]
 
 % Orifis katsayıları
 orf = struct();
 orf.Cd0   = 0.61;                    % Re → 0 limitindeki boşalım katsayısı
+orf_Cd0_vals = orf.Cd0;              % Tarama aralığı
 orf.CdInf = 0.80;                    % Yüksek Re için boşalım katsayısı
+orf_CdInf_vals = orf.CdInf;          % Tarama aralığı
 orf.Rec   = 3000;                    % Kritik Reynolds sayısı
+orf_Rec_vals = orf.Rec;              % Tarama aralığı
 orf.p_exp = 1.1;                     % Geçiş eğrisinin eğimi
+orf_p_exp_vals = orf.p_exp;          % Tarama aralığı
 orf.p_amb = 1.0e5;                   % Ortam basıncı [Pa]
+orf_p_amb_vals = orf.p_amb;          % Tarama aralığı
 orf.p_cav_eff = 2.0e3;               % Etkin kavitasyon eşiği [Pa]
+orf_p_cav_eff_vals = orf.p_cav_eff;  % Tarama aralığı
 orf.cav_sf    = 0.90;                % Kavitasyon emniyet katsayısı
+orf_cav_sf_vals = orf.cav_sf;        % Tarama aralığı
 orf.d_o   = d_o;                     % Re düzeltmesi için çap [m]
 orf.veps  = 0.10;                    % Düşük hız yumuşatma [m/s]
 
@@ -88,6 +105,7 @@ T_ref_C   = 25;                      % Referans sıcaklık [°C]
 b_mu      = -0.013;                  % Viskozite-sıcaklık katsayısı
 thermal = struct();
 thermal.hA_W_perK = 450;             % Konvektif ısı kaybı katsayısı
+thermal_hA_vals = thermal.hA_W_perK; % Tarama aralığı
 thermal.T_env_C   = 25;              % Ortam sıcaklığı [°C]
 thermal.max_iter  = 3;               % ΔT iterasyon sayısı
 thermal.tol_K     = 0.5;             % Yakınsama toleransı [K]
@@ -113,7 +131,9 @@ c_lam_min      = max(c_lam_min_abs, c_lam_min_frac*c_lam0);
 cfg = struct();
 cfg.PF.mode      = 'ramp';
 cfg.PF.tau       = 0.05;
+cfg_PF_tau_vals  = cfg.PF.tau;       % Tarama aralığı
 cfg.PF.gain      = 1.0;
+cfg_PF_gain_vals = cfg.PF.gain;      % Tarama aralığı
 cfg.PF.t_on      = 0;
 cfg.PF.auto_t_on = true;
 cfg.on.pressure_force     = true;

--- a/toggle/run_param_grid.m
+++ b/toggle/run_param_grid.m
@@ -6,24 +6,31 @@
 parametreler; %#ok<*NASGU>
 
 % Tarama yapılacak parametre dizileri
-ndps_vals = n_dampers_per_story(:);
-gain_vals = toggle_gain(:);
+vals = {Dp_vals(:), Lgap_vals(:), d_o_vals(:), Lori_vals(:), mu_ref_vals(:), ...
+        d_w_vals(:), D_m_vals(:), n_turn_vals(:), rho_vals(:), n_orf_vals(:), ...
+        orf_Cd0_vals(:), orf_CdInf_vals(:), orf_Rec_vals(:), orf_p_exp_vals(:), ...
+        orf_p_amb_vals(:), orf_p_cav_eff_vals(:), orf_cav_sf_vals(:), ...
+        thermal_hA_vals(:), cfg_PF_tau_vals(:), cfg_PF_gain_vals(:), ...
+        n_dampers_per_story(:), toggle_gain(:)};
+varNames = {'Dp','Lgap','d_o','Lori','mu_ref','d_w','D_m','n_turn','rho','n_orf', ...
+            'orf_Cd0','orf_CdInf','orf_Rec','orf_p_exp','orf_p_amb','orf_p_cav_eff','orf_cav_sf', ...
+            'thermal_hA_W_perK','cfg_PF_tau','cfg_PF_gain','n_dampers_per_story','toggle_gain'};
 
 % 2) Tüm kombinasyonları üret
-[NDPS, GAIN] = ndgrid(ndps_vals, gain_vals);
-comb = [NDPS(:), GAIN(:)];
+grid = cell(1,numel(vals));
+[grid{:}] = ndgrid(vals{:});
+comb = zeros(numel(grid{1}), numel(vals));
+for k = 1:numel(grid)
+    comb(:,k) = grid{k}(:);
+end
 
 % 3) Yer hareketi kaydını yükle (hızlı olması için ilk kayıt)
 [~, scaled] = load_ground_motions(T1);
 rec = scaled(1);
 
-% 4) Temel parametre yapısı (tarama dışındaki parametreler)
-base_params = struct('M',M,'C0',C0,'K',K,'k_sd',k_sd,'c_lam0',c_lam0, ...
-    'orf',orf,'rho',rho,'Ap',Ap,'A_o',A_o,'Qcap_big',Qcap_big,'mu_ref',mu_ref, ...
-    'thermal',thermal,'T0_C',T0_C,'T_ref_C',T_ref_C,'b_mu',b_mu, ...
-    'c_lam_min',c_lam_min,'c_lam_cap',c_lam_cap,'Lgap',Lgap, ...
-    'cp_oil',cp_oil,'cp_steel',cp_steel,'steel_to_oil_mass_ratio',steel_to_oil_mass_ratio, ...
-    'story_mask',story_mask,'resFactor',resFactor,'cfg',cfg,'story_height',story_height);
+% Baz yapılar
+thermal_base = thermal;
+cfg_base = cfg;
 
 % Çıktı dosyası
 outdir = 'out'; if ~exist(outdir,'dir'), mkdir(outdir); end
@@ -31,17 +38,76 @@ outfile = fullfile(outdir, 'param_grid_results.csv');
 if exist(outfile,'file'), delete(outfile); end
 all_results = table();
 
-% 5) Parametre kombinasyonları üzerinde döngü
+% 4) Parametre kombinasyonları üzerinde döngü
 opts = struct('use_orifice', true, 'use_thermal', true);
 for i = 1:size(comb,1)
-    params = base_params;
-    params.n_dampers_per_story = comb(i,1);
-    params.toggle_gain = comb(i,2);
+    % --- Parametreleri ayıkla ---
+    Dp_i    = comb(i,1);   Lgap_i = comb(i,2);   d_o_i  = comb(i,3);
+    Lori_i  = comb(i,4);   mu_i   = comb(i,5);   d_w_i  = comb(i,6);
+    D_m_i   = comb(i,7);   n_turn_i = comb(i,8); rho_i  = comb(i,9);
+    n_orf_i = comb(i,10);  Cd0_i = comb(i,11);   CdInf_i = comb(i,12);
+    Rec_i   = comb(i,13);  p_exp_i = comb(i,14); p_amb_i = comb(i,15);
+    p_cav_i = comb(i,16);  cav_sf_i = comb(i,17);
+    hA_i    = comb(i,18);  PF_tau_i = comb(i,19); PF_gain_i = comb(i,20);
+    ndps_i  = comb(i,21);  gain_i   = comb(i,22);
 
+    % --- Türetilmiş büyüklükler ---
+    Ap_i    = pi*Dp_i^2/4;
+    k_h     = Kd*Ap_i^2/Lgap_i;
+    k_s     = Ebody*Ap_i/Lgap_i;
+    k_hyd   = 1/(1/k_h + 1/k_s);
+    k_p     = Gsh*d_w_i^4/(8*n_turn_i*D_m_i^3);
+    k_sd_i  = k_hyd + k_p;
+    c_lam0_i= 12*mu_i*Lori_i*Ap_i^2/d_o_i^4;
+    A_o_i   = n_orf_i * (pi*d_o_i^2/4);
+    orf_i = struct('Cd0',Cd0_i,'CdInf',CdInf_i,'Rec',Rec_i,'p_exp',p_exp_i, ...
+                   'p_amb',p_amb_i,'p_cav_eff',p_cav_i,'cav_sf',cav_sf_i, ...
+                   'd_o',d_o_i,'veps',orf.veps);
+    Qcap_big_i = max(orf_i.CdInf*A_o_i,1e-9) * sqrt(2*1.0e9/rho_i);
+    thermal_i = thermal_base; thermal_i.hA_W_perK = hA_i;
+    cfg_i = cfg_base; cfg_i.PF.tau = PF_tau_i; cfg_i.PF.gain = PF_gain_i;
+    c_lam_min_i = max(c_lam_min_abs, c_lam_min_frac*c_lam0_i);
+
+    params = struct('M',M,'C0',C0,'K',K,'k_sd',k_sd_i,'c_lam0',c_lam0_i, ...
+        'orf',orf_i,'rho',rho_i,'Ap',Ap_i,'A_o',A_o_i,'Qcap_big',Qcap_big_i,'mu_ref',mu_i, ...
+        'thermal',thermal_i,'T0_C',T0_C,'T_ref_C',T_ref_C,'b_mu',b_mu, ...
+        'c_lam_min',c_lam_min_i,'c_lam_cap',c_lam_cap,'Lgap',Lgap_i, ...
+        'cp_oil',cp_oil,'cp_steel',cp_steel,'steel_to_oil_mass_ratio',steel_to_oil_mass_ratio, ...
+        'story_mask',story_mask,'resFactor',resFactor,'cfg',cfg_i,'story_height',story_height);
+    params.n_dampers_per_story = ndps_i;
+    params.toggle_gain = gain_i;
+
+    % --- Simülasyon ---
     out = run_one_record_windowed(rec, [], params, opts);
-    row = table(params.n_dampers_per_story, params.toggle_gain, ...
-        out.metr.PFA_top, out.metr.IDR_max, out.metr.dP_orf_q95, ...
-        'VariableNames', {'n_dampers_per_story','toggle_gain','PFA_top','IDR_max','dP_orf_q95'});
+    w = out.worst;
+
+    % Koruma amaçlı yardımcılar
+    if isfield(w,'x10_max_D'), x10 = w.x10_max_D; elseif isfield(w,'x10_pk_D'), x10 = w.x10_pk_D; else, x10 = NaN; end
+    if isfield(w,'a10abs_max_D'), a10 = w.a10abs_max_D; elseif isfield(w,'a10abs_pk_D'), a10 = w.a10abs_pk_D; else, a10 = NaN; end
+    dP95 = Utils.getfield_default(w,'dP_orf_q95',NaN);
+    Qcap95 = Utils.getfield_default(w,'Qcap_ratio_q95',NaN);
+    cav   = Utils.getfield_default(w,'cav_pct',NaN);
+    Tend  = Utils.getfield_default(w,'T_oil_end',NaN);
+    muend = Utils.getfield_default(w,'mu_end',NaN);
+    PFp95 = Utils.getfield_default(w,'PF_p95',NaN);
+    Qq50  = Utils.getfield_default(w,'Q_q50',NaN);
+    Qq95  = Utils.getfield_default(w,'Q_q95',NaN);
+    dPq50 = Utils.getfield_default(w,'dP_orf_q50',NaN);
+    dPq95 = Utils.getfield_default(w,'dP_orf_q95',dP95);
+    Tsteel= Utils.getfield_default(w,'T_steel_end',NaN);
+    Eor   = Utils.getfield_default(w,'E_orifice_full',NaN);
+    Estr  = Utils.getfield_default(w,'E_struct_full',NaN);
+    Eratio= Utils.getfield_default(w,'E_ratio_full',NaN);
+    Etot  = Eor + Estr;
+
+    % Sonuç satırı
+    param_vals = comb(i,:);
+    metr_vals = [x10, a10, dP95, Qcap95, cav, Tend, muend, PFp95, Qq50, Qq95, dPq50, dPq95, Tend, Tsteel, Etot, Eor, Estr, Eratio];
+    row = array2table([param_vals, metr_vals], 'VariableNames', [varNames, ...
+        {'x10_max_damperli','a10abs_max_damperli','dP95_worst','Qcap95_worst', ...
+         'cav_pct_worst','T_end_worst','mu_end_worst','PF_p95_worst','Q_q50_worst', ...
+         'Q_q95_worst','dP_orf_q50_worst','dP_orf_q95_worst','T_oil_end_worst', ...
+         'T_steel_end_worst','energy_tot_sum','E_orifice_sum','E_struct_sum','E_ratio'}]);
     all_results = [all_results; row]; %#ok<AGROW>
 
     if i == 1
@@ -52,3 +118,4 @@ for i = 1:size(comb,1)
 end
 
 disp(all_results);
+


### PR DESCRIPTION
## Summary
- enable sweeping of damper, orifice, thermal, and PF parameters via new *_vals arrays
- expand run_param_grid to iterate over all parameter combinations and capture additional performance metrics

## Testing
- ⚠️ `octave --eval "run('run_param_grid.m')"` *(octave: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a2341bb08328b9814d6bcf50054d