### PR TITLE
Add default QC threshold helper

### DIFF
--- a/4/Utils.m
+++ b/4/Utils.m
@@ -177,5 +177,28 @@ classdef Utils
                 P(:,i) = vals;
             end
         end
+
+        %% Default QC Thresholds
+        function thr = default_qc_thresholds(optsThr)
+            % Return default quality-control thresholds and fill missing fields.
+            % Example: thr = Utils.default_qc_thresholds(struct('dP95_max',40e6));
+
+            if nargin < 1 || isempty(optsThr)
+                optsThr = struct();
+            end
+
+            thr = struct();
+            thr.dP95_max   = Utils.getfield_default(optsThr,'dP95_max',50e6);
+            thr.Qcap95_max = Utils.getfield_default(optsThr,'Qcap95_max',0.5);
+            thr.cav_pct_max= Utils.getfield_default(optsThr,'cav_pct_max',0);
+            thr.T_end_max  = Utils.getfield_default(optsThr,'T_end_max',75);
+            thr.mu_end_min = Utils.getfield_default(optsThr,'mu_end_min',0.5);
+
+            % Preserve any additional fields
+            extra = setdiff(fieldnames(optsThr), fieldnames(thr));
+            for ii = 1:numel(extra)
+                thr.(extra{ii}) = optsThr.(extra{ii});
+            end
+        end
     end
 end


### PR DESCRIPTION
## Summary
- expose `default_qc_thresholds` as a static method in `4/Utils.m`
- preserve default and extra QC threshold fields via `getfield_default`

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `sudo apt-get install -y octave` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ad4562c8328a728a7bdbec79501