### PR TITLE
Add softmin epsilon utility and QC threshold helper

### DIFF
--- a/4/Utils.m
+++ b/4/Utils.m
@@ -38,6 +38,15 @@ classdef Utils
             y = 0.5*(a + b - sqrt((a - b).^2 + epsm.^2));
         end
 
+        function epsm = softmin_eps(cfg)
+            if nargin < 1 || ~isstruct(cfg)
+                cfg = struct();
+            end
+            num  = Utils.getfield_default(cfg,'num',struct());
+            epsm = Utils.getfield_default(num,'softmin_eps',1e5);
+            epsm = max(1e3, double(epsm));
+        end
+
         function w = pf_weight(t, cfg)
             w = cfg.on.pressure_force * (1 - exp(-max(t - cfg.PF.t_on, 0) ./ max(cfg.PF.tau, 1e-6)));
         end
@@ -175,6 +184,29 @@ classdef Utils
                     vals = lb(i) + rand(N,1).*(ub(i)-lb(i));
                 end
                 P(:,i) = vals;
+            end
+        end
+
+        %% Default QC Thresholds
+        function thr = default_qc_thresholds(optsThr)
+            % Return default quality-control thresholds and fill missing fields.
+            % Example: thr = Utils.default_qc_thresholds(struct('dP95_max',40e6));
+
+            if nargin < 1 || isempty(optsThr)
+                optsThr = struct();
+            end
+
+            thr = struct();
+            thr.dP95_max   = Utils.getfield_default(optsThr,'dP95_max',50e6);
+            thr.Qcap95_max = Utils.getfield_default(optsThr,'Qcap95_max',0.5);
+            thr.cav_pct_max= Utils.getfield_default(optsThr,'cav_pct_max',0);
+            thr.T_end_max  = Utils.getfield_default(optsThr,'T_end_max',75);
+            thr.mu_end_min = Utils.getfield_default(optsThr,'mu_end_min',0.5);
+
+            % Preserve any additional fields
+            extra = setdiff(fieldnames(optsThr), fieldnames(thr));
+            for ii = 1:numel(extra)
+                thr.(extra{ii}) = optsThr.(extra{ii});
             end
         end
     end

--- a/4/mck_with_damper.m
+++ b/4/mck_with_damper.m
@@ -21,6 +21,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0, use_orf,orf,rho,A
     Tser = T0_C*ones(numel(t),1);
     mu_abs = mu_ref;
     c_lam    = c_lam0;
+    epsm     = Utils.softmin_eps(cfg);
 
     % Solve ODE
     odef = @(tt,z) [ z(n+1:end); M \ ( -C*z(n+1:end) - K*z(1:n) - dev_force(tt,z(1:n),z(n+1:end),c_lam,mu_abs) - M*r*agf(tt) ) ];
@@ -40,7 +41,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0, use_orf,orf,rho,A
         dP_calc = 0.5*rho .* ( qmag ./ max(Cd.*Ao,1e-9) ).^2;
         p_up   = orf.p_amb + abs(F_lin)./max(Ap,1e-12);
         dP_cav = max( (p_up - orf.p_cav_eff).*orf.cav_sf, 0 );
-        dP_orf = Utils.softmin(dP_calc,dP_cav,1e5);
+        dP_orf = Utils.softmin(dP_calc,dP_cav,epsm);
         sgn = dvel ./ sqrt(dvel.^2 + orf.veps^2);
         F_orf = dP_orf .* Ap .* sgn;
         F_p = F_lin + F_orf;
@@ -112,7 +113,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0, use_orf,orf,rho,A
             dP_calc_ = 0.5*rho .* ( qmag_ ./ max(Cd_.*Ao,1e-9) ).^2;
             p_up_   = orf.p_amb + abs(F_lin_)./max(Ap,1e-12);
             dP_cav_ = max( (p_up_ - orf.p_cav_eff).*orf.cav_sf, 0 );
-            dP_orf_ = Utils.softmin(dP_calc_,dP_cav_,1e5);
+            dP_orf_ = Utils.softmin(dP_calc_,dP_cav_,epsm);
             sgn_ = dvel_ ./ sqrt(dvel_.^2 + orf.veps^2);
             F_orf_ = dP_orf_ .* Ap .* sgn_;
         end


### PR DESCRIPTION
## Summary
- expose `softmin_eps` as static util to obtain smoothing epsilon from cfg
- use `softmin_eps` in `mck_with_damper` instead of hardcoded constant
- expose `default_qc_thresholds` as a static method in `Utils`

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `octave --path 4 --eval "disp(Utils.softmin_eps(struct()))"`
- `octave --path 4 --eval "cfg.num.softmin_eps=12345; disp(Utils.softmin_eps(cfg))"`


------
https://chatgpt.com/codex/tasks/task_e_68c69ad4562c8328a728a7bdbec79501