### PR TITLE
Use T0_C field in thermal struct

### DIFF
--- a/4/GA/mck_with_damper.m
+++ b/4/GA/mck_with_damper.m
@@ -1,5 +1,5 @@
 function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,rho,Ap,Ao,Qcap, mu_ref, ...
-    use_thermal, thermal, T0_C,T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
+    use_thermal, thermal, T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
     cp_oil,cp_steel, steel_to_oil_mass_ratio, story_mask, ...
     n_dampers_per_story, resFactor, cfg)
 %% Girdi Parametreleri
@@ -16,7 +16,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     Nvec = 1:nStories; Mvec = 2:n;
 
     % Başlangıç sıcaklığı ve viskozitesi
-    Tser = T0_C*ones(numel(t),1);
+    Tser = thermal.T0_C*ones(numel(t),1);
     mu_abs = mu_ref;
     c_lam = c_lam0;
 
@@ -85,7 +85,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     m_steel_tot = steel_to_oil_mass_ratio*m_oil_tot;
     C_oil   = max(m_oil_tot*cp_oil,   eps);
     C_steel = max(m_steel_tot*cp_steel, eps);
-    T_o = Tser; T_s = T0_C*ones(numel(t),1);
+    T_o = Tser; T_s = thermal.T0_C*ones(numel(t),1);
     hA_os   = Utils.getfield_default(thermal, 'hA_os',    thermal.hA_W_perK);
     hA_o_env= Utils.getfield_default(thermal, 'hA_o_env', thermal.hA_W_perK);
     hA_s_env= Utils.getfield_default(thermal, 'hA_s_env', thermal.hA_W_perK);
@@ -96,8 +96,8 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
         dT_s = ( + hA_os*(T_o(k)-T_s(k)) - hA_s_env*(T_s(k)-thermal.T_env_C) ) / C_steel;
         T_o(k+1) = T_o(k) + dtv(k)*dT_o;
         T_s(k+1) = T_s(k) + dtv(k)*dT_s;
-        T_o(k+1) = min(max(T_o(k+1), T0_C), T0_C + thermal.dT_max);
-        T_s(k+1) = min(max(T_s(k+1), T0_C), T0_C + thermal.dT_max);
+        T_o(k+1) = min(max(T_o(k+1), thermal.T0_C), thermal.T0_C + thermal.dT_max);
+        T_s(k+1) = min(max(T_s(k+1), thermal.T0_C), thermal.T0_C + thermal.dT_max);
     end
     mu = mu_ref*exp(b_mu*(T_o - T_ref_C));
 

--- a/4/GA/parametreler.m
+++ b/4/GA/parametreler.m
@@ -88,6 +88,7 @@ T0_C      = 25;                      % Başlangıç sıcaklığı [°C]
 T_ref_C   = 25;                      % Referans sıcaklık [°C]
 b_mu      = -0.013;                  % Viskozite-sıcaklık katsayısı
 thermal = struct();
+thermal.T0_C = T0_C;
 thermal.hA_W_perK = 450;             % Konvektif ısı kaybı katsayısı
 thermal.T_env_C   = 25;              % Ortam sıcaklığı [°C]
 thermal.max_iter  = 3;               % ΔT iterasyon sayısı

--- a/4/GA/run_one_record_windowed.m
+++ b/4/GA/run_one_record_windowed.m
@@ -125,11 +125,13 @@ switch mode
             td = 0;
         end
         hA = params.thermal.hA_W_perK;
-        Tenv = params.thermal.T_env_C;
-        Tinit = Tenv + (Tprev - Tenv) * exp(-hA*td / C_th);
+    Tenv = params.thermal.T_env_C;
+    Tinit = Tenv + (Tprev - Tenv) * exp(-hA*td / C_th);
     otherwise
         Tinit = params.T0_C;
 end
+
+params.thermal.T0_C = Tinit;
 
 %% Sönümleyicisiz Çözüm
 % Lineer MCK sistemi sönümleyici olmadan çözülür.
@@ -164,7 +166,7 @@ for i = 1:nMu
     end
     [x,a_rel,ts,diag] = mck_with_damper_ts(rec.t, rec.ag, params.M, params.C0, params.K, ...
         params.k_sd, c_lam0_eff, params.Lori, opts.use_orifice, params.orf, params.rho, params.Ap, ...
-        params.A_o, params.Qcap_big, mu_ref_eff, opts.use_thermal, params.thermal, Tinit, ...
+        params.A_o, params.Qcap_big, mu_ref_eff, opts.use_thermal, params.thermal, ...
         params.T_ref_C, params.b_mu, params.c_lam_min, params.c_lam_cap, params.Lgap, ...
         params.cp_oil, params.cp_steel, params.steel_to_oil_mass_ratio, ...
         params.story_mask, params.n_dampers_per_story, params.resFactor, params.cfg);
@@ -195,7 +197,7 @@ diag = mu_results(nom_idx).diag;
 T_start = Tinit;
 if isfield(diag,'T_oil')
     T_end = diag.T_oil(end);
-    Tmax = params.T0_C + params.thermal.dT_max;
+    Tmax = params.thermal.T0_C + params.thermal.dT_max;
     clamp_hits = sum(diff(diag.T_oil >= Tmax) > 0);
 else
     T_end = NaN;
@@ -291,14 +293,14 @@ end
 %% =====================================================================
 function [x,a_rel,ts,diag] = mck_with_damper_ts(t,ag,M,C,K, k_sd,c_lam0,Lori, ...
     use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, ...
-    T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, ...
+    T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, ...
     steel_to_oil_mass_ratio, story_mask, n_dampers_per_story, ...
     resFactor, cfg)
 %1) MCK_WITH_DAMPER çözümü
 [x,a_rel,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orifice, orf, ...
-    rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, T0_C, T_ref_C, b_mu, ...
+    rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, T_ref_C, b_mu, ...
     c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, ...
- story_mask, n_dampers_per_story, resFactor, cfg);
+    story_mask, n_dampers_per_story, resFactor, cfg);
 
 %2) Öykü vektörlerinin hazırlanması
 nStories = size(diag.drift,2);

--- a/4/diagnostic.m
+++ b/4/diagnostic.m
@@ -19,7 +19,7 @@ use_thermal = true;
 
 [x0,a0] = lin_MCK(t,ag,M,C0,K);
 [x,a,diag_out] = mck_with_damper(t,ag,M,C0,K, k_sd,c_lam0, Lori, use_orifice, orf, rho, Ap, A_o, Qcap_big, mu_ref, ...
-    use_thermal, thermal, T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, ...
+    use_thermal, thermal, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, ...
     cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
     n_dampers_per_story, resFactor, cfg);
 
@@ -67,7 +67,7 @@ end
 
 %% Damper model with diagnostics
 function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,rho,Ap,Ao,Qcap, mu_ref, ...
-    use_thermal, thermal, T0_C,T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
+    use_thermal, thermal, T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
     cp_oil,cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
     n_dampers_per_story, resFactor, cfg)
 
@@ -86,7 +86,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     Nvec = 1:nStories; Mvec = 2:n;
 
     % Initial temperature and viscosity
-    Tser = T0_C*ones(numel(t),1);
+    Tser = thermal.T0_C*ones(numel(t),1);
     mu_abs = mu_ref;
     c_lam = c_lam0;
     epsm   = Utils.softmin_eps(cfg);
@@ -147,7 +147,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     for k=1:numel(t)-1
         Pk = 0.5*(P_sum(k)+P_sum(k+1));
         Tser(k+1) = Tser(k) + dtv(k)*( Pk/C_th - (thermal.hA_W_perK/C_th)*(Tser(k)-thermal.T_env_C) );
-        Tser(k+1) = min(max(Tser(k+1), T0_C), T0_C + thermal.dT_max);
+        Tser(k+1) = min(max(Tser(k+1), thermal.T0_C), thermal.T0_C + thermal.dT_max);
     end
     mu = mu_ref*exp(b_mu*(Tser - T_ref_C));
 

--- a/4/mck_with_damper.m
+++ b/4/mck_with_damper.m
@@ -1,5 +1,5 @@
 function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,rho,Ap,Ao,Qcap, mu_ref, ...
-    use_thermal, thermal, T0_C,T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
+    use_thermal, thermal, T_ref_C,b_mu, c_lam_min,c_lam_cap,Lgap, ...
     cp_oil,cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
     n_dampers_per_story, resFactor, cfg)
 
@@ -18,7 +18,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     Nvec = 1:nStories; Mvec = 2:n;
 
     % Initial temperature and viscosity
-    Tser = T0_C*ones(numel(t),1);
+    Tser = thermal.T0_C*ones(numel(t),1);
     mu_abs = mu_ref;
     c_lam    = c_lam0;
     epsm     = Utils.softmin_eps(cfg);
@@ -81,7 +81,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
     for k=1:numel(t)-1
         Pk = 0.5*(P_sum(k)+P_sum(k+1));
         Tser(k+1) = Tser(k) + dtv(k)*( Pk/C_th - (thermal.hA_W_perK/C_th)*(Tser(k)-thermal.T_env_C) );
-        Tser(k+1) = min(max(Tser(k+1), T0_C), T0_C + thermal.dT_max);
+        Tser(k+1) = min(max(Tser(k+1), thermal.T0_C), thermal.T0_C + thermal.dT_max);
     end
     mu = mu_ref*exp(b_mu*(Tser - T_ref_C));
 

--- a/4/mck_with_damper_ts.m
+++ b/4/mck_with_damper_ts.m
@@ -1,4 +1,4 @@
-function [x,a_rel,ts,diag] = mck_with_damper_ts(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, n_dampers_per_story, resFactor, cfg)
+function [x,a_rel,ts,diag] = mck_with_damper_ts(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, use_thermal, thermal, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, n_dampers_per_story, resFactor, cfg)
 %MCK_WITH_DAMPER_TS Wrapper around MCK_WITH_DAMPER returning time-series.
 %
 %   [X,A_REL,TS,DIAG] = MCK_WITH_DAMPER_TS(T,AG,M,C,K, ...) calls the existing
@@ -9,7 +9,7 @@ function [x,a_rel,ts,diag] = mck_with_damper_ts(t,ag,M,C,K, k_sd,c_lam0,Lori, us
 
 % Solve using the existing implementation
 [x,a_rel,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orifice, orf, rho, Ap, Ao, Qcap, mu_ref, ...
-    use_thermal, thermal, T0_C, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, ...
+    use_thermal, thermal, T_ref_C, b_mu, c_lam_min, c_lam_cap, Lgap, ...
     cp_oil, cp_steel, steel_to_oil_mass_ratio, toggle_gain, story_mask, ...
     n_dampers_per_story, resFactor, cfg);
 

--- a/4/parametreler.m
+++ b/4/parametreler.m
@@ -87,6 +87,7 @@ T0_C      = 25;                      % Başlangıç sıcaklığı [°C]
 T_ref_C   = 25;                      % Referans sıcaklık [°C]
 b_mu      = -0.013;                  % Viskozite-sıcaklık katsayısı
 thermal = struct();
+thermal.T0_C = T0_C;
 thermal.hA_W_perK = 450;             % Konvektif ısı kaybı katsayısı
 thermal.T_env_C   = 25;              % Ortam sıcaklığı [°C]
 thermal.max_iter  = 3;               % ΔT iterasyon sayısı

--- a/4/run_one_record_windowed.m
+++ b/4/run_one_record_windowed.m
@@ -139,6 +139,8 @@ switch mode
         Tinit = params.T0_C;
 end
 
+params.thermal.T0_C = Tinit;
+
 %% ---------------------- Damperless solution -------------------------
 [x0,a_rel0] = Utils.lin_MCK(rec.t, rec.ag, params.M, params.C0, params.K);
 ts0 = struct('dP_orf',zeros(numel(rec.t),nStories), ...
@@ -163,7 +165,7 @@ for i = 1:nMu
     c_lam0_eff   = params.c_lam0  * f;
     [x,a_rel,ts,diag] = mck_with_damper_ts(rec.t, rec.ag, params.M, params.C0, params.K, ...
         params.k_sd, c_lam0_eff, params.Lori, opts.use_orifice, params.orf, params.rho, params.Ap, ...
-        params.A_o, params.Qcap_big, mu_ref_eff, opts.use_thermal, params.thermal, Tinit, ...
+        params.A_o, params.Qcap_big, mu_ref_eff, opts.use_thermal, params.thermal, ...
         params.T_ref_C, params.b_mu, params.c_lam_min, params.c_lam_cap, params.Lgap, ...
         params.cp_oil, params.cp_steel, params.steel_to_oil_mass_ratio, params.toggle_gain, ...
         params.story_mask, params.n_dampers_per_story, params.resFactor, params.cfg);
@@ -194,7 +196,7 @@ diag = mu_results(nom_idx).diag;
 T_start = Tinit;
 if isfield(diag,'T_oil')
     T_end = diag.T_oil(end);
-    Tmax = params.T0_C + params.thermal.dT_max;
+    Tmax = params.thermal.T0_C + params.thermal.dT_max;
     clamp_hits = sum(diff(diag.T_oil >= Tmax) > 0);
 else
     T_end = NaN;


### PR DESCRIPTION
## Summary
- Store initial oil temperature inside the `thermal` struct for shared access.
- Drop the separate `T0_C` argument from damper solver routines and use `thermal.T0_C` for initialization and clamping.
- Update all call sites and wrappers, including GA utilities, to match the new solver signature.

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('hi')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6deee8d9c832880508aacc28c08a3