### PR TITLE
Fix GA SDOF utilities

### DIFF
--- a/4/GA/mck_with_damper.m
+++ b/4/GA/mck_with_damper.m
@@ -55,7 +55,12 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
         dP_cav_loc= max( (p_up_loc - orf.p_cav_eff).*orf.cav_sf, 0 );
         F_p = F_lin + F_orf;
     else
-        F_p = F_lin; Q = 0*dvel; dP_orf = 0*dvel; P_orf_per = 0*dvel;
+        F_p = F_lin;
+        Q = 0*dvel;
+        dP_orf = 0*dvel;
+        P_orf_per = 0*dvel;
+        dP_kv_loc = 0*dvel;
+        dP_cav_loc = 0*dvel;
     end
 
     dp_pf = (c_lam*dvel + (F_p - k_sd*drift)) ./ Ap;

--- a/4/GA/sdof.m
+++ b/4/GA/sdof.m
@@ -8,9 +8,13 @@ clear; clc; close all;
 %% Load base parameters
 parametreler;  % loads structural and damper parameters and computes T1
 
-%% Override with GA best parameters from ga_front.csv
+%% Override with GA best parameters from GA output
 try
-    tbl = readtable('ga_knee.csv');
+    if exist('ga_knee.csv','file')
+        tbl = readtable('ga_knee.csv');
+    else
+        tbl = readtable('ga_front.csv');
+    end
     xb = tbl(1,:);
 
     d_o   = xb.d_o_mm/1000;      % [m]
@@ -134,8 +138,7 @@ x10_max_d    = max(abs(x10_orf));
 a10abs_max_0 = max(abs(a10_0));
 a10abs_max_d = max(abs(a10_orf));
 
-fprintf('Self-check zeta1: %.3f %% (dampersiz) vs %.3f %% (damperli)\n', 100*zeta0, 100*zeta_d);
-fprintf('x10_max  (dampersiz)   = %.4g m\n', x10_max_0);
-fprintf('x10_max  (damperli)    = %.4g m\n', x10_max_d);
-fprintf('a10abs_max  (dampersiz)= %.4g m/s^2\n', a10abs_max_0);
-fprintf('a10abs_max  (damperli) = %.4g m/s^2\n', a10abs_max_d);
+fprintf(['Self-check zeta1: %.3f%% (dampersiz) vs %.3f%% (damperli); ' ...
+         'x10_{max}0=%.4g m; x10_{max}d=%.4g m; ' ...
+         'a10abs_{max}0=%.4g m/s^2; a10abs_{max}d=%.4g m/s^2\n'], ...
+        100*zeta0, 100*zeta_d, x10_max_0, x10_max_d, a10abs_max_0, a10abs_max_d);


### PR DESCRIPTION
## Summary
- Ensure mck\_with\_damper always defines pressure-drop diagnostics even without orifice flow
- Allow SDOF script to load GA best parameters and print metrics in a single summary line

## Testing
- `matlab -batch "sdof"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f12612248328b13bb3776bf8e986