### PR TITLE
Fix GA SDOF utilities

### DIFF
--- a/4/GA/mck_with_damper.m
+++ b/4/GA/mck_with_damper.m
@@ -55,7 +55,12 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
         dP_cav_loc= max( (p_up_loc - orf.p_cav_eff).*orf.cav_sf, 0 );
         F_p = F_lin + F_orf;
     else
-        F_p = F_lin; Q = 0*dvel; dP_orf = 0*dvel; P_orf_per = 0*dvel;
+        F_p = F_lin;
+        Q = 0*dvel;
+        dP_orf = 0*dvel;
+        P_orf_per = 0*dvel;
+        dP_kv_loc = 0*dvel;
+        dP_cav_loc = 0*dvel;
     end
 
     dp_pf = (c_lam*dvel + (F_p - k_sd*drift)) ./ Ap;

--- a/4/GA/sdof.m
+++ b/4/GA/sdof.m
@@ -4,13 +4,19 @@
 % acceleration histories for the 10th floor along with peak metrics.
 
 clear; clc; close all;
+figdir = fullfile('out','sdof_figs');
+if ~exist(figdir,'dir'), mkdir(figdir); end
 
 %% Load base parameters
 parametreler;  % loads structural and damper parameters and computes T1
 
-%% Override with GA best parameters from ga_front.csv
+%% Override with GA best parameters from GA output
 try
-    tbl = readtable('ga_knee.csv');
+    if exist('ga_knee.csv','file')
+        tbl = readtable('ga_knee.csv');
+    else
+        tbl = readtable('ga_front.csv');
+    end
     xb = tbl(1,:);
 
     d_o   = xb.d_o_mm/1000;      % [m]
@@ -92,7 +98,7 @@ phi1 = V(:,ord(1)); w1 = sqrt(w2(1));
 normM = phi1.' * M * phi1;
 
 %% Plots: 10th floor displacement and acceleration, plus IDR
-figure('Name','10. Kat yer değiştirme — ham ivme (ODE-only)','Color','w');
+f1 = figure('Name','10. Kat yer değiştirme — ham ivme (ODE-only)','Color','w');
 plot(t, x10_0 ,'k','LineWidth',1.4); hold on;
 plot(t, x10_lin,'b','LineWidth',1.1);
 plot(t, x10_orf,'r','LineWidth',1.0);
@@ -101,8 +107,9 @@ plot([t95 t95],yl,'k--','HandleVisibility','off');
 grid on; xlabel('t [s]'); ylabel('x10(t) [m]');
 title(sprintf('10-Kat | T1=%.3f s | Arias [%.3f, %.3f] s', T1, t5, t95));
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+saveas(f1, fullfile(figdir,'disp.png'));
 
-figure('Name','10. Kat mutlak ivme','Color','w');
+f2 = figure('Name','10. Kat mutlak ivme','Color','w');
 plot(t, a10_0 ,'k','LineWidth',1.4); hold on;
 plot(t, a10_lin,'b','LineWidth',1.1);
 plot(t, a10_orf,'r','LineWidth',1.0);
@@ -110,6 +117,7 @@ yl = ylim; plot([t5 t5],yl,'k--','HandleVisibility','off');
 plot([t95 t95],yl,'k--','HandleVisibility','off');
 grid on; xlabel('t [s]'); ylabel('a10abs(t) [m/s^2]');
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+saveas(f2, fullfile(figdir,'acc.png'));
 
 drift0    = x0(:,2:end)   - x0(:,1:end-1);
 drift_lin = x_lin(:,2:end) - x_lin(:,1:end-1);
@@ -118,12 +126,13 @@ IDR0      = max(abs(drift0))./story_height;
 IDR_lin   = max(abs(drift_lin))./story_height;
 IDR_orf   = max(abs(drift_orf))./story_height;
 story_ids = 1:(n-1);
-figure('Name','Maksimum IDR','Color','w');
+f3 = figure('Name','Maksimum IDR','Color','w');
 plot(story_ids, IDR0,'k-o','LineWidth',1.4); hold on;
 plot(story_ids, IDR_lin,'b-s','LineWidth',1.1);
 plot(story_ids, IDR_orf,'r-d','LineWidth',1.0);
 grid on; xlabel('Kat'); ylabel('Maks IDR [Delta x/h]');
 legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+saveas(f3, fullfile(figdir,'idr.png'));
 
 %% Summary printout
 zeta0 = (phi1.' * C0 * phi1) / (2*w1*normM);
@@ -134,8 +143,8 @@ x10_max_d    = max(abs(x10_orf));
 a10abs_max_0 = max(abs(a10_0));
 a10abs_max_d = max(abs(a10_orf));
 
-fprintf('Self-check zeta1: %.3f %% (dampersiz) vs %.3f %% (damperli)\n', 100*zeta0, 100*zeta_d);
-fprintf('x10_max  (dampersiz)   = %.4g m\n', x10_max_0);
-fprintf('x10_max  (damperli)    = %.4g m\n', x10_max_d);
-fprintf('a10abs_max  (dampersiz)= %.4g m/s^2\n', a10abs_max_0);
-fprintf('a10abs_max  (damperli) = %.4g m/s^2\n', a10abs_max_d);
+fprintf(['Self-check zeta1: %.3f%% (dampersiz) vs %.3f%% (damperli); ' ...
+         'x10_{max}0=%.4g m; x10_{max}d=%.4g m; ' ...
+         'a10abs_{max}0=%.4g m/s^2; a10abs_{max}d=%.4g m/s^2\n'], ...
+        100*zeta0, 100*zeta_d, x10_max_0, x10_max_d, a10abs_max_0, a10abs_max_d);
+fprintf('Figures saved to %s\n', figdir);


### PR DESCRIPTION
## Summary
- Ensure mck_with_damper always defines pressure-drop diagnostics even without orifice flow
- Allow SDOF script to load GA best parameters and print metrics in a single summary line
- Save SDOF displacement, acceleration and IDR plots to `out/sdof_figs` for headless runs

## Testing
- `matlab -batch "sdof"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f12612248328b13bb3776bf8e986