### PR TITLE
Simplify SDOF script to use GA damper metrics

### DIFF
--- a/4/GA/sdof.m
+++ b/4/GA/sdof.m
@@ -56,89 +56,82 @@ win = Utils.make_arias_window(t, ag); t5 = win.t5; t95 = win.t95;
 
 %% Damperless and damper responses
 [x0,a_rel0] = Utils.lin_MCK(t, ag, M, C0, K);
-[x_lin,a_lin,diag_lin] = mck_with_damper(t, ag, M, C0, K, k_sd, c_lam0, Lori, false, ...
-    orf, rho, Ap, A_o, Qcap_big, mu_ref, false, thermal, T0_C, T_ref_C, b_mu, ...
-    c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, ...
-    story_mask, n_dampers_per_story, resFactor, cfg);
-[x_orf,a_orf,diag_orf] = mck_with_damper(t, ag, M, C0, K, k_sd, c_lam0, Lori, true, ...
+[x_d,a_d,diag_d] = mck_with_damper(t, ag, M, C0, K, k_sd, c_lam0, Lori, true, ...
     orf, rho, Ap, A_o, Qcap_big, mu_ref, true, thermal, T0_C, T_ref_C, b_mu, ...
     c_lam_min, c_lam_cap, Lgap, cp_oil, cp_steel, steel_to_oil_mass_ratio, ...
     story_mask, n_dampers_per_story, resFactor, cfg);
 
-x10_0   = x0(:,10);  x10_lin = x_lin(:,10);  x10_orf = x_orf(:,10);
-a10_0   = a_rel0(:,10) + ag;
-a10_lin = a_lin(:,10) + ag;
-a10_orf = a_orf(:,10) + ag;
+x10_0 = x0(:,10);
+x10_d = x_d(:,10);
+a10_0 = a_rel0(:,10) + ag;
+a10_d = a_d(:,10) + ag;
 
 %% Assemble equivalent damping/stiffness matrices for modal check
 nStories = n - 1;
 mask = story_mask(:); if numel(mask)==1, mask = mask*ones(nStories,1); end
 ndps = n_dampers_per_story(:); if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
 multi = (mask .* ndps);
-Kadd = zeros(n); Cl_add = zeros(n); Co_add = zeros(n);
+Kadd = zeros(n); C_add = zeros(n);
 for i = 1:nStories
     idx = [i,i+1];
-    k_eq   = k_sd * multi(i);
-    c_eq_l = diag_lin.c_lam * multi(i);
-    c_eq_o = diag_orf.c_lam * multi(i);
-    kM  = k_eq  * [1 -1; -1 1];
-    cMl = c_eq_l* [1 -1; -1 1];
-    cMo = c_eq_o* [1 -1; -1 1];
-    Kadd(idx,idx)  = Kadd(idx,idx)  + kM;
-    Cl_add(idx,idx)= Cl_add(idx,idx)+ cMl;
-    Co_add(idx,idx)= Co_add(idx,idx)+ cMo;
+    k_eq = k_sd * multi(i);
+    c_eq = diag_d.c_lam * multi(i);
+    kM  = k_eq * [1 -1; -1 1];
+    cM  = c_eq * [1 -1; -1 1];
+    Kadd(idx,idx) = Kadd(idx,idx) + kM;
+    C_add(idx,idx)= C_add(idx,idx) + cM;
 end
 K_tot = K + Kadd;
-C_lin = C0 + Cl_add;
-C_orf = C0 + Co_add;
+C_d = C0 + C_add;
 [V,D] = eig(K_tot,M); [w2,ord] = sort(diag(D),'ascend');
 phi1 = V(:,ord(1)); w1 = sqrt(w2(1));
 normM = phi1.' * M * phi1;
 
 %% Plots: 10th floor displacement and acceleration, plus IDR
 figure('Name','10. Kat yer değiştirme — ham ivme (ODE-only)','Color','w');
-plot(t, x10_0 ,'k','LineWidth',1.4); hold on;
-plot(t, x10_lin,'b','LineWidth',1.1);
-plot(t, x10_orf,'r','LineWidth',1.0);
+plot(t, x10_0,'k','LineWidth',1.4); hold on;
+plot(t, x10_d,'r','LineWidth',1.0);
 yl = ylim; plot([t5 t5],yl,'k--','HandleVisibility','off');
 plot([t95 t95],yl,'k--','HandleVisibility','off');
 grid on; xlabel('t [s]'); ylabel('x10(t) [m]');
 title(sprintf('10-Kat | T1=%.3f s | Arias [%.3f, %.3f] s', T1, t5, t95));
-legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+legend('Dampersiz','Damperli','Location','best');
 
 figure('Name','10. Kat mutlak ivme','Color','w');
-plot(t, a10_0 ,'k','LineWidth',1.4); hold on;
-plot(t, a10_lin,'b','LineWidth',1.1);
-plot(t, a10_orf,'r','LineWidth',1.0);
+plot(t, a10_0,'k','LineWidth',1.4); hold on;
+plot(t, a10_d,'r','LineWidth',1.0);
 yl = ylim; plot([t5 t5],yl,'k--','HandleVisibility','off');
 plot([t95 t95],yl,'k--','HandleVisibility','off');
 grid on; xlabel('t [s]'); ylabel('a10abs(t) [m/s^2]');
-legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+legend('Dampersiz','Damperli','Location','best');
 
-drift0    = x0(:,2:end)   - x0(:,1:end-1);
-drift_lin = x_lin(:,2:end) - x_lin(:,1:end-1);
-drift_orf = x_orf(:,2:end) - x_orf(:,1:end-1);
-IDR0      = max(abs(drift0))./story_height;
-IDR_lin   = max(abs(drift_lin))./story_height;
-IDR_orf   = max(abs(drift_orf))./story_height;
+drift0 = x0(:,2:end) - x0(:,1:end-1);
+drift_d = x_d(:,2:end) - x_d(:,1:end-1);
+idx = win.idx;
+IDR0 = max(abs(drift0(idx,:)))./story_height;
+IDR_d = max(abs(drift_d(idx,:)))./story_height;
 story_ids = 1:(n-1);
 figure('Name','Maksimum IDR','Color','w');
 plot(story_ids, IDR0,'k-o','LineWidth',1.4); hold on;
-plot(story_ids, IDR_lin,'b-s','LineWidth',1.1);
-plot(story_ids, IDR_orf,'r-d','LineWidth',1.0);
+plot(story_ids, IDR_d,'r-d','LineWidth',1.0);
 grid on; xlabel('Kat'); ylabel('Maks IDR [Delta x/h]');
-legend('Dampersiz','Lineer damper','Orifisli damper','Location','best');
+legend('Dampersiz','Damperli','Location','best');
 
 %% Summary printout
 zeta0 = (phi1.' * C0 * phi1) / (2*w1*normM);
-zeta_d = (phi1.' * (C0 + Co_add) * phi1) / (2*w1*normM);
+zeta_d = (phi1.' * C_d * phi1) / (2*w1*normM);
 
-x10_max_0    = max(abs(x10_0));
-x10_max_d    = max(abs(x10_orf));
-a10abs_max_0 = max(abs(a10_0));
-a10abs_max_d = max(abs(a10_orf));
+idx = win.idx;
+x10_max_0 = max(abs(x10_0(idx)));
+x10_max_damperli = max(abs(x10_d(idx)));
+a10abs_max_0 = max(abs(a10_0(idx)));
+a10abs_max_damperli = max(abs(a10_d(idx)));
+IDR_max_0 = max(IDR0);
+IDR_max_damperli = max(IDR_d);
 
 fprintf(['Self-check zeta1: %.3f%% (dampersiz) vs %.3f%% (damperli); ' ...
          'x10_{max}0=%.4g m; x10_{max}d=%.4g m; ' ...
-         'a10abs_{max}0=%.4g m/s^2; a10abs_{max}d=%.4g m/s^2\n'], ...
-        100*zeta0, 100*zeta_d, x10_max_0, x10_max_d, a10abs_max_0, a10abs_max_d);
+         'a10abs_{max}0=%.4g m/s^2; a10abs_{max}d=%.4g m/s^2; ' ...
+         'IDR_{max}0=%.4g; IDR_{max}d=%.4g\n'], ...
+        100*zeta0, 100*zeta_d, x10_max_0, x10_max_damperli, ...
+        a10abs_max_0, a10abs_max_damperli, IDR_max_0, IDR_max_damperli);


### PR DESCRIPTION
## Summary
- Replace separate linear/orifice damper runs with a single damper analysis
- Plot and report damper metrics using GA-style peak displacement, acceleration, and IDR

## Testing
- `octave -qf 4/GA/sdof.m` *(fails: 'parametreler' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fa9bdeec832891433541367ae980