### PR TITLE
Expose PF resistive slope in configuration

### DIFF
--- a/4/GA/mck_with_damper.m
+++ b/4/GA/mck_with_damper.m
@@ -65,7 +65,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
 
     dp_pf = (c_lam*dvel + (F_p - k_sd*drift)) ./ Ap;
     if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
-        s = tanh(20*dvel);
+        s = tanh(cfg.PF.resistive_slope*dvel);
         dp_pf = s .* max(0, s .* dp_pf);
     end
     w_pf_vec = Utils.pf_weight(t, cfg) * cfg.PF.gain;
@@ -135,7 +135,7 @@ function [x,a,diag] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, use_orf,orf,
         end
         dp_pf_ = (c_lam_loc*dvel_ + F_orf_) ./ Ap;
         if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
-            s = tanh(20*dvel_);
+            s = tanh(cfg.PF.resistive_slope*dvel_);
             dp_pf_ = s .* max(0, s .* dp_pf_);
         end
         w_pf = Utils.pf_weight(tt,cfg) * cfg.PF.gain;

--- a/4/GA/run_one_record_windowed.m
+++ b/4/GA/run_one_record_windowed.m
@@ -29,6 +29,13 @@ if ~isfield(opts,'mu_weights'), opts.mu_weights = 1; end
 % Türetilmiş damper sabitlerini güncelle
 params = Utils.recompute_damper_params(params);
 
+% Ensure PF resistive slope parameter is available
+if ~isfield(params,'cfg') || ~isstruct(params.cfg), params.cfg = struct(); end
+if ~isfield(params.cfg,'PF') || ~isstruct(params.cfg.PF), params.cfg.PF = struct(); end
+if ~isfield(params.cfg.PF,'resistive_slope') || isempty(params.cfg.PF.resistive_slope)
+    params.cfg.PF.resistive_slope = 20;
+end
+
 if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
     if ~isfield(opts,'cooldown_s') || isempty(opts.cooldown_s) || isnan(opts.cooldown_s)
         opts.cooldown_s = 60;


### PR DESCRIPTION
## Summary
- read PF resistive-only clamp slope from `cfg.PF.resistive_slope` instead of hardcoding
- default `cfg.PF.resistive_slope` to 20 in windowed record runner

## Testing
- `octave -qf --eval "addpath('4/GA'); cfg=struct('on',struct('pressure_force',1), 'PF', struct('resistive_slope',20)); w=Utils.pf_weight(0, cfg); disp(w);"`

------
https://chatgpt.com/codex/tasks/task_e_68c7242ebfc48328aa10e586354019ec