### PR TITLE
Refactor laminar damping using pressure drops

### DIFF
--- a/4/GA/Utils.m
+++ b/4/GA/Utils.m
@@ -98,8 +98,9 @@ classdef Utils
             k_sd_simple = k_hyd + k_p;      % tek damper
             k_sd_adv    = nd * (k_hyd + k_p);% paralel nd
 
-            % Laminer sabit (tek damper referansı)
-            c_lam0 = 12 * params.mu_ref * params.Lori * Ap^2 / (params.orf.d_o^4);
+            % Laminer referans direnci ve eşdeğer sönüm
+            R_lam_ref = (128 * params.mu_ref * params.Lori / (pi * params.orf.d_o^4)) / max(nd*params.n_orf,1);
+            c_eff_ref = (Ap_eff^2) * R_lam_ref;
 
             % Çıkışlar (geriye uyumlu alan adlarıyla)
             params.Ap = Ap;
@@ -112,7 +113,9 @@ classdef Utils
             % Adım 2 öncesi: k_sd paralel etkili (nd içselleştirilmiş) seçilir
             params.k_sd = k_sd_adv;
 
-            params.c_lam0 = c_lam0;
+            % Yeni laminer parametreleri
+            params.R_lam_ref = R_lam_ref;
+            params.c_lam0 = c_eff_ref; % geri uyumlu alan adı
         end
 
         %% Lineer MCK Çözümü


### PR DESCRIPTION
## Summary
- Compute reference laminar resistance and effective damping in `recompute_damper_params`
- Replace velocity-based viscous force with pressure-based laminar drop and orifice pressure combination
- Rescale laminar effects by viscosity with a physical floor

## Testing
- ❌ `octave --version` *(command not found)*
- ⚠️ `apt-get install -y octave` *(failed: Sub-process /usr/bin/dpkg returned an error code (1))*

------
https://chatgpt.com/codex/tasks/task_e_68c7298e356c8328989d84c06ad1195e