### PR TITLE
Remove multi-mu evaluation paths

### DIFF
--- a/4/GA/make_sizing_case.m
+++ b/4/GA/make_sizing_case.m
@@ -103,7 +103,7 @@ function [sizing, P_sized, S_worst] = make_sizing_case(scaled, params, gainsPF, 
 
     %% Adım 2: Sabit Kazançlarla Sistem Değerlendirmesi
     O = struct('do_export',false,'quiet',true,'thermal_reset','each','order','natural', ...
-               'mu_factors',[0.75 1.00 1.25], 'mu_weights',[0.2 0.6 0.2], 'thr', []);
+               'thr', []);
     S_worst = run_batch_windowed(scaled, P, O);
 
     %% Adım 3: Q95 ve Basınç Sınırlarının Belirlenmesi
@@ -160,11 +160,8 @@ function [Q95_worst, dp_kv_target, dp_cap] = find_Q95_worst(S_worst, O, dp_allow
     Q95_worst = NaN;
     try
         vars = S_worst.table.Properties.VariableNames;
-        if ismember('Q_q95_worst', vars)
-            v = S_worst.table.Q_q95_worst;
-            Q95_worst = max(v(:));
-        elseif ismember('Q_q95_w', vars)
-            v = S_worst.table.Q_q95_w;
+        if ismember('Q_q95', vars)
+            v = S_worst.table.Q_q95;
             Q95_worst = max(v(:));
         end
     catch

--- a/4/GA/run_batch_windowed.m
+++ b/4/GA/run_batch_windowed.m
@@ -14,8 +14,6 @@ function [summary, all_out] = run_batch_windowed(scaled, params, opts)
 %   raporlanır.
 
 if nargin < 3, opts = struct(); end
-if ~isfield(opts,'mu_factors'), opts.mu_factors = 1.00; end
-if ~isfield(opts,'mu_weights'), opts.mu_weights = 1; end
 if ~isfield(opts,'thr'), opts.thr = struct(); end
 opts.thr = Utils.default_qc_thresholds(opts.thr);
 
@@ -67,45 +65,24 @@ else
 end
 cooldown_col = repmat(cooldown_val, n,1);
 
-PFA_nom    = zeros(n,1);
-IDR_nom    = zeros(n,1);
-dP95_nom   = zeros(n,1);
-Qcap95_nom = zeros(n,1);
-cav_nom    = zeros(n,1);
+PFA    = zeros(n,1);
+IDR    = zeros(n,1);
+dP95   = zeros(n,1);
+Qcap95 = zeros(n,1);
+cav_pct = zeros(n,1);
 zeta1_hot       = zeros(n,1);
 z2_over_z1_hot  = zeros(n,1);
 P_mech      = zeros(n,1);
 Re_max      = zeros(n,1);
-
-PFA_w    = zeros(n,1);
-IDR_w    = zeros(n,1);
-dP95_w   = zeros(n,1);
-Qcap95_w = zeros(n,1);
-Q_q95_w  = zeros(n,1);
-Q_q50_w  = zeros(n,1);
-dP50_w   = zeros(n,1);
-
-PFA_worst    = zeros(n,1);
-IDR_worst    = zeros(n,1);
-dP95_worst   = zeros(n,1);
-Qcap95_worst = zeros(n,1);
-Q_q95_worst  = zeros(n,1);
-Q_q50_worst  = zeros(n,1);
-dP_orf_q50_worst = zeros(n,1);
-PF_p95_worst = zeros(n,1);
-which_mu_PFA = zeros(n,1);
-which_mu_IDR = zeros(n,1);
-T_end_worst  = zeros(n,1);
-mu_end_worst = zeros(n,1);
-cav_pct_worst = zeros(n,1);
-    % Damperli üst kat için yeni en kötü durum tepe metrikleri
-x10_max_D_worst = zeros(n,1);
-a10abs_max_D_worst = zeros(n,1);
-    % Enerji özetleri (mu boyunca en kötü değer)
-E_orifice_sum = zeros(n,1);
-E_struct_sum  = zeros(n,1);
-E_ratio       = zeros(n,1);
-qc_all_mu    = false(n,1);
+Q_q95  = zeros(n,1);
+Q_q50  = zeros(n,1);
+dP50   = zeros(n,1);
+x10_max_D = zeros(n,1);
+a10abs_max_D = zeros(n,1);
+E_orifice = zeros(n,1);
+E_struct  = zeros(n,1);
+E_ratio   = zeros(n,1);
+qc_pass   = false(n,1);
 
 T_start    = zeros(n,1);
 T_end      = zeros(n,1);
@@ -115,8 +92,8 @@ clamp_hits = zeros(n,1);
 Dp_mm_col   = repmat(Utils.getfield_default(params,'Dp_mm',NaN), n,1);
 mu_ref_col  = repmat(Utils.getfield_default(params,'mu_ref',NaN), n,1);
 
-worstPFA = -inf; worstPFA_name = ''; worstPFA_mu = NaN;
-worstIDR = -inf; worstIDR_name = ''; worstIDR_mu = NaN;
+worstPFA = -inf; worstPFA_name = '';
+worstIDR = -inf; worstIDR_name = '';
 
 %% Kayıt Döngüsü
 % Her kayıt için pencere analizi
@@ -144,79 +121,33 @@ for k = 1:n
     T_end(k)      = out.T_end;
     mu_end(k)     = out.mu_end;
     clamp_hits(k) = out.clamp_hits;
-
     m_nom = out.metr;
-    PFA_nom(k)    = m_nom.PFA_top;
-    IDR_nom(k)    = m_nom.IDR_max;
-    dP95_nom(k)   = m_nom.dP_orf_q95;
-    Qcap95_nom(k) = m_nom.Qcap_ratio_q95;
-    cav_nom(k)    = m_nom.cav_pct;
+    PFA(k)    = m_nom.PFA_top;
+    IDR(k)    = m_nom.IDR_max;
+    dP95(k)   = m_nom.dP_orf_q95;
+    Qcap95(k) = m_nom.Qcap_ratio_q95;
+    cav_pct(k)= m_nom.cav_pct;
     zeta1_hot(k)       = Utils.getfield_default(m_nom,'zeta1_hot',NaN);
     z2_over_z1_hot(k)  = Utils.getfield_default(m_nom,'z2_over_z1_hot',NaN);
     P_mech(k)          = Utils.getfield_default(m_nom,'P_mech',NaN);
     Re_max(k)          = Utils.getfield_default(m_nom,'Re_max',NaN);
+    Q_q95(k)  = Utils.getfield_default(m_nom,'Q_q95',NaN);
+    Q_q50(k)  = Utils.getfield_default(m_nom,'Q_q50',NaN);
+    dP50(k)   = Utils.getfield_default(m_nom,'dP_orf_q50',NaN);
+    x10_max_D(k) = Utils.getfield_default(m_nom,'x10_max_D',Utils.getfield_default(m_nom,'x10_pk_D',NaN));
+    a10abs_max_D(k) = Utils.getfield_default(m_nom,'a10abs_max_D',Utils.getfield_default(m_nom,'a10abs_pk_D',NaN));
+    E_orifice(k) = Utils.getfield_default(m_nom,'E_orifice_full',NaN);
+    E_struct(k)  = Utils.getfield_default(m_nom,'E_struct_full',NaN);
+    E_ratio(k)   = Utils.getfield_default(m_nom,'E_ratio_full',NaN);
+    qc_pass(k)   = out.qc_pass;
 
-    m_w = out.weighted;
-    PFA_w(k)    = m_w.PFA_top;
-    IDR_w(k)    = m_w.IDR_max;
-    dP95_w(k)   = m_w.dP_orf_q95;
-    Qcap95_w(k) = m_w.Qcap_ratio_q95;
-    fields  = {'Q_q95','Q_q50','dP_orf_q50'};
-    targets = {Q_q95_w, Q_q50_w, dP50_w};
-    for f = 1:numel(fields)
-        targets{f} = Utils.assign_if_field(m_w, fields{f}, targets{f}, k);
-    end
-    [Q_q95_w, Q_q50_w, dP50_w] = targets{:};
-
-    m_ws = out.worst;
-    PFA_worst(k)    = m_ws.PFA_top;
-    IDR_worst(k)    = m_ws.IDR_max;
-    dP95_worst(k)   = m_ws.dP_orf_q95;
-    Qcap95_worst(k) = m_ws.Qcap_ratio_q95;
-    fields  = {'Q_q95','Q_q50','dP_orf_q50','PF_p95'};
-    targets = {Q_q95_worst, Q_q50_worst, dP_orf_q50_worst, PF_p95_worst};
-    for f = 1:numel(fields)
-        targets{f} = Utils.assign_if_field(m_ws, fields{f}, targets{f}, k);
-    end
-    [Q_q95_worst, Q_q50_worst, dP_orf_q50_worst, PF_p95_worst] = targets{:};
-    which_mu_PFA(k) = m_ws.which_mu.PFA_top;
-    which_mu_IDR(k) = m_ws.which_mu.IDR_max;
-    T_end_worst(k)  = m_ws.T_oil_end;
-    mu_end_worst(k) = m_ws.mu_end;
-    cav_pct_worst(k)= m_ws.cav_pct;
-    % Üst kat zarf metrikleri
-    fields  = {'x10_max_D','a10abs_max_D'};
-    targets = {x10_max_D_worst, a10abs_max_D_worst};
-    for f = 1:numel(fields)
-        targets{f} = Utils.assign_if_field(m_ws, fields{f}, targets{f}, k);
-        if ~isfield(m_ws, fields{f})
-            fallback = strrep(fields{f}, '_max_', '_pk_');
-            targets{f} = Utils.assign_if_field(m_ws, fallback, targets{f}, k);
-        end
-    end
-    [x10_max_D_worst, a10abs_max_D_worst] = targets{:};
-    % Enerji toplamları
-    fields  = {'E_orifice_full','E_struct_full','E_ratio_full'};
-    targets = {E_orifice_sum, E_struct_sum, E_ratio};
-    for f = 1:numel(fields)
-        targets{f} = Utils.assign_if_field(m_ws, fields{f}, targets{f}, k);
-    end
-    [E_orifice_sum, E_struct_sum, E_ratio] = targets{:};
-    qc_all_mu(k)    = out.qc_all_mu;
-
-    valsPFA = arrayfun(@(s) s.metr.PFA_top, out.mu_results);
-    [maxPFA_rec, idxPFA] = max(valsPFA);
-    if maxPFA_rec > worstPFA
-        worstPFA = maxPFA_rec;
+    if PFA(k) > worstPFA
+        worstPFA = PFA(k);
         worstPFA_name = out.name;
-        worstPFA_mu   = out.mu_results(idxPFA).mu_factor;
     end
-    valsIDR = arrayfun(@(s) s.metr.IDR_max, out.mu_results);
-    [maxIDR_rec, idxIDR] = max(valsIDR);
-    if maxIDR_rec > worstIDR
-        worstIDR = maxIDR_rec;
+    if IDR(k) > worstIDR
+        worstIDR = IDR(k);
         worstIDR_name = out.name;
-        worstIDR_mu   = out.mu_results(idxIDR).mu_factor;
     end
 end
 
@@ -225,37 +156,24 @@ end
 summary = struct();
 
 summary.table = table(names, scale, SaT1, t5, t95, coverage, rank_score, policy_col, order_col, cooldown_col, ...
-    PFA_nom, IDR_nom, dP95_nom, Qcap95_nom, cav_nom, zeta1_hot, z2_over_z1_hot, P_mech, Re_max, ...
-    PFA_w, IDR_w, dP95_w, Qcap95_w, Q_q95_w, Q_q50_w, dP50_w, ...
-    PFA_worst, IDR_worst, dP95_worst, dP_orf_q50_worst, Qcap95_worst, Q_q95_worst, Q_q50_worst, PF_p95_worst, ...
-    cav_pct_worst, x10_max_D_worst, a10abs_max_D_worst, E_orifice_sum, E_struct_sum, E_ratio, ...
-    which_mu_PFA, which_mu_IDR, T_end_worst, mu_end_worst, qc_all_mu, ...
+    PFA, IDR, dP95, Qcap95, cav_pct, zeta1_hot, z2_over_z1_hot, P_mech, Re_max, ...
+    Q_q95, Q_q50, dP50, x10_max_D, a10abs_max_D, E_orifice, E_struct, E_ratio, qc_pass, ...
     T_start, T_end, mu_end, clamp_hits, Dp_mm_col, mu_ref_col, ...
     'VariableNames', {'name','scale','SaT1','t5','t95','coverage','rank_score','policy','order','cooldown_s', ...
-    'PFA_nom','IDR_nom','dP95_nom','Qcap95_nom','cav_nom','zeta1_hot','z2_over_z1_hot','P_mech','Re_max', ...
-    'PFA_w','IDR_w','dP95_w','Qcap95_w','Q_q95_w','Q_q50_w','dP50_w', ...
-    'PFA_worst','IDR_worst','dP95_worst','dP_orf_q50_worst','Qcap95_worst','Q_q95_worst','Q_q50_worst','PF_p95_worst', ...
-    'cav_pct_worst','x10_max_D_worst','a10abs_max_D_worst','E_orifice_sum','E_struct_sum','E_ratio', ...
-    'which_mu_PFA','which_mu_IDR','T_end_worst','mu_end_worst','qc_all_mu', ...
+    'PFA','IDR','dP95','Qcap95','cav_pct','zeta1_hot','z2_over_z1_hot','P_mech','Re_max', ...
+    'Q_q95','Q_q50','dP50','x10_max_D','a10abs_max_D','E_orifice','E_struct','E_ratio','qc_pass', ...
     'T_start','T_end','mu_end','clamp_hits','Dp_mm','mu_ref'});
 
-% Tüketicilerle uyumluluk için takma adlar
-summary.table.T_oil_end_worst = summary.table.T_end_worst;
-summary.table.dP_orf_q95_worst = summary.table.dP95_worst;
-try
-    summary.table.energy_tot_sum = summary.table.E_orifice_sum + summary.table.E_struct_sum;
-catch
-end
 summary.all_out = all_out;
 %% QC Kontrolü
 % QC eşiklerine göre sonuçların değerlendirilmesi
 % --- summary.csv kullanıcıları için QC bayrakları ve sebep kodları ---
 thr = opts.thr;
-ok_T    = summary.table.T_end_worst   <= thr.T_end_max;
-ok_mu   = summary.table.mu_end_worst  >= thr.mu_end_min;
-ok_dP   = summary.table.dP95_worst    <= thr.dP95_max;
-ok_Qcap = summary.table.Qcap95_worst  <  thr.Qcap95_max;
-ok_cav  = summary.table.cav_pct_worst == 0;
+ok_T    = summary.table.T_end   <= thr.T_end_max;
+ok_mu   = summary.table.mu_end  >= thr.mu_end_min;
+ok_dP   = summary.table.dP95    <= thr.dP95_max;
+ok_Qcap = summary.table.Qcap95  <  thr.Qcap95_max;
+ok_cav  = summary.table.cav_pct == 0;
 qc_reason = strings(height(summary.table),1);
 for r = 1:height(summary.table)
     bad = {};
@@ -274,8 +192,8 @@ summary.table.ok_cav = ok_cav;
 summary.table.qc_reason = qc_reason;
 
 if ~isfield(opts,'quiet') || ~opts.quiet
-    fprintf('Worst PFA: %s, mu=%.2f\n', worstPFA_name, worstPFA_mu);
-    fprintf('Worst IDR: %s, mu=%.2f\n', worstIDR_name, worstIDR_mu);
+    fprintf('Worst PFA: %s\n', worstPFA_name);
+    fprintf('Worst IDR: %s\n', worstIDR_name);
 end
 
 if do_export


### PR DESCRIPTION
## Summary
- Drop support for multi-µ evaluation across the run suite
- Simplify batch, policy, GA driver, and sizing case pipelines to use single-µ results

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7548427448328a93a0ffb64476272