### PR TITLE
Handle missing base workspace variables in GA driver

### DIFF
--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -26,12 +26,17 @@ parpool_hard_reset(16);
         params_local = [];
     end
     % Girdi verilmemişse (ör. editörde Run'a basıldığında) GA'nın başlayabilmesi
-    % için temel çalışma alanından 'scaled' ve 'params' değişkenlerini almaya çalış.
+    % için temel çalışma alanında değişkenlerin varlığını kontrol et.
+    % Yoksa boş bırak; aşağıdaki "auto-prep" bloğu eksikleri doldurur.
     if isempty(scaledOrSnap_local)
-        scaledOrSnap_local = evalin('base','scaled');
+        if evalin('base','exist(''scaled'',''var'')')
+            scaledOrSnap_local = evalin('base','scaled');
+        end
     end
     if isempty(params_local)
-        params_local = evalin('base','params');
+        if evalin('base','exist(''params'',''var'')')
+            params_local = evalin('base','params');
+        end
     end
     if nargin < 3 || isempty(optsEval), optsEval = struct; end
     if nargin < 4 || isempty(optsGA),   optsGA   = struct; end
@@ -227,12 +232,28 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
             v_Tend = Si.table.T_end;
             v_mu   = Si.table.mu_end;
 
-            v_PFp95 = Si.table.PF_p95;
-            v_Qq50  = Si.table.Q_q50;
-            v_Qq95  = Si.table.Q_q95;
-            v_dPq50 = Si.table.dP50;
-        v_Toil = [];
-        v_Tsteel = [];
+            if ismember('PF_p95', Si.table.Properties.VariableNames)
+                v_PFp95 = Si.table.PF_p95;
+            else
+                v_PFp95 = 0;
+            end
+            if ismember('Q_q50', Si.table.Properties.VariableNames)
+                v_Qq50 = Si.table.Q_q50;
+            else
+                v_Qq50 = 0;
+            end
+            if ismember('Q_q95', Si.table.Properties.VariableNames)
+                v_Qq95 = Si.table.Q_q95;
+            else
+                v_Qq95 = 0;
+            end
+            if ismember('dP50', Si.table.Properties.VariableNames)
+                v_dPq50 = Si.table.dP50;
+            else
+                v_dPq50 = 0;
+            end
+            v_Toil = [];
+            v_Tsteel = [];
 
         if ismember('E_orifice_sum', Si.table.Properties.VariableNames)
             v_Eor = Si.table.E_orifice_sum;


### PR DESCRIPTION
## Summary
- Guard against missing `scaled` and `params` variables when launching `run_ga_driver`
- Safely handle absent metrics like `PF_p95` in GA post-processing

## Testing
- `matlab -batch "run('4/GA/run_ga_driver.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c75b91c374832890b121c138c142ec