### PR TITLE
Refactor thermal capacity and default handling

### DIFF
--- a/4/GA/Utils.m
+++ b/4/GA/Utils.m
@@ -319,5 +319,20 @@ classdef Utils
                 thr.(extra{ii}) = optsThr.(extra{ii});
             end
         end
+
+        %% Etkin Termal Kapasite
+        function Cth = compute_Cth_effective(params)
+            %COMPUTE_CTH_EFFECTIVE Toplam etkin termal kapasiteyi hesaplar.
+            nStories = size(params.M,1) - 1;
+            mask = params.story_mask(:);
+            if numel(mask)==1, mask = mask*ones(nStories,1); end
+            ndps = params.n_dampers_per_story(:);
+            if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
+            multi = (mask .* ndps);
+            V_oil_per = params.resFactor * (params.Ap * (2*params.Lgap));
+            m_oil_tot = sum(multi) * (params.rho * V_oil_per);
+            m_steel_tot = params.steel_to_oil_mass_ratio * m_oil_tot;
+            Cth = max(m_oil_tot*params.cp_oil + m_steel_tot*params.cp_steel, eps);
+        end
     end
 end

--- a/4/GA/export_results.m
+++ b/4/GA/export_results.m
@@ -17,7 +17,8 @@ params = Utils.recompute_damper_params(params);
 
     % Varsa türetilmiş parametreler
     params_derived = struct();
-        params_derived.C_th = compute_Cth_effective(params);
+        % Thermal mass derived parameter uses shared utility
+        params_derived.C_th = Utils.compute_Cth_effective(params);
 
     % qc özet bilgisi
         pass = sum(summary.table.qc_pass);
@@ -152,17 +153,4 @@ if ~isempty(varargin)
 end
 
 end % export_results fonksiyon sonu
-
-%%% --- Yardımcı Fonksiyonlar ---
-function Cth = compute_Cth_effective(params)
-    % Sıcaklık kapasitesinin etkin değerini hesaplar
-    nStories = size(params.M,1) - 1;
-        mask = params.story_mask(:);  if numel(mask)==1, mask = mask*ones(nStories,1); end
-    ndps = params.n_dampers_per_story(:); if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
-    multi = (mask .* ndps);
-    V_oil_per = params.resFactor * (params.Ap * (2*params.Lgap));
-    m_oil_tot = sum(multi) * (params.rho * V_oil_per);
-    m_steel_tot = params.steel_to_oil_mass_ratio * m_oil_tot;
-    Cth = max(m_oil_tot*params.cp_oil + m_steel_tot*params.cp_steel, eps);
-end
 

--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -55,8 +55,7 @@ parpool_hard_reset(16);
             params = params_local;
         end
         meta = struct();
-        if ~isfield(S,'thr'), S.thr = struct(); end
-        meta.thr       = Utils.default_qc_thresholds(S.thr);
+        meta.thr = Utils.default_qc_thresholds(Utils.getfield_default(S,'thr', struct()));
     else
         scaled = scaledOrSnap_local;
         params = params_local;
@@ -68,12 +67,11 @@ parpool_hard_reset(16);
                 % Temel parametreleri yükle ve T1 hesapla
                 parametreler;
                 % Veri kümesini ölçekle (band/trim) ve dondur
-                    % Auto‑prep: dışarıdan sağlanmışsa yükleme seçeneklerini kullan
-                    if exist('optsGA','var') && isstruct(optsGA) && isfield(optsGA,'load_opts')
-                        [~, scaled] = load_ground_motions(T1, optsGA.load_opts);
-                    else
-                        % IM ayarlarını tamamen varsayılanlara bırak
+                    load_opts = Utils.getfield_default(optsGA,'load_opts',[]);
+                    if isempty(load_opts)
                         [~, scaled] = load_ground_motions(T1);
+                    else
+                        [~, scaled] = load_ground_motions(T1, load_opts);
                     end
                 % Parametre yapısını oluştur (damperlinon yansısı)
                 params = struct('M',M,'C0',C0,'K',K,'k_sd',k_sd,'c_lam0',c_lam0,'Lori',Lori, ...
@@ -97,8 +95,7 @@ parpool_hard_reset(16);
     if nargin < 3 || isempty(optsEval), optsEval = struct; end
     optsEval.do_export     = false;
     optsEval.quiet         = true;
-    if ~isfield(optsEval,'thr'), optsEval.thr = meta.thr; end
-    optsEval.thr = Utils.default_qc_thresholds(optsEval.thr);
+    optsEval.thr = Utils.default_qc_thresholds(Utils.getfield_default(optsEval,'thr', meta.thr));
     %% GA Kurulumu
     % GA amaç fonksiyonu ve optimizasyon seçeneklerini hazırla.
     if nargin < 4 || isempty(optsGA), optsGA = struct; end
@@ -128,7 +125,7 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
 
     %% Başlangıç Popülasyonu
     % Izgaraya hizalı ilk popülasyonu oluştur (tohumlarla birlikte).
-        if ~isfield(optsGA,'InitialPopulationMatrix') || isempty(optsGA.InitialPopulationMatrix)
+        if isempty(Utils.getfield_default(optsGA,'InitialPopulationMatrix',[]))
             step_vec = [0.1 NaN 0.01 0.02 0.01 0.01 0.05 1 25 1 0.5 5 NaN 0.05 0.1];
             P0 = Utils.initial_pop_grid(lb, ub, options.PopulationSize, step_vec);
             % Tohumlar (yeni sınırlar içinde uygulanabilir)

--- a/4/GA/run_one_record_windowed.m
+++ b/4/GA/run_one_record_windowed.m
@@ -84,14 +84,7 @@ else
 end
 
 % soğuma seçeneği için termal kapasite hesaplanır
- nStories = size(params.M,1) - 1;
- mask = params.story_mask(:);  if numel(mask)==1, mask = mask*ones(nStories,1); end
- ndps = params.n_dampers_per_story(:); if numel(ndps)==1, ndps = ndps*ones(nStories,1); end
- multi = (mask .* ndps);
-V_oil_per = params.resFactor * (params.Ap * (2*params.Lgap));
- m_oil_tot = sum(multi) * (params.rho * V_oil_per);
- m_steel_tot = params.steel_to_oil_mass_ratio * m_oil_tot;
- C_th = max(m_oil_tot*params.cp_oil + m_steel_tot*params.cp_steel, eps);
+C_th = Utils.compute_Cth_effective(params);
 
 switch mode
     case 'each'


### PR DESCRIPTION
## Summary
- Centralize thermal capacity calculation via `Utils.compute_Cth_effective`
- Use `Utils.getfield_default` for option defaults in GA driver
- Simplify thermal cooldown logic to reuse shared utility

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp(1)"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7660f7ac88328854948120e642f1e