### PR TITLE
Centralize damper parameter initialization

### DIFF
--- a/4/GA/build_params.m
+++ b/4/GA/build_params.m
@@ -1,0 +1,29 @@
+function params = build_params(params)
+%BUILD_PARAMS Compute derived damper and hydraulic fields once.
+%   PARAMS = BUILD_PARAMS(PARAMS) fills in fields such as Ap, k_sd,
+%   c_lam0, Qcap_big and c_lam_min based on the fundamental geometry and
+%   material properties stored in PARAMS. The input struct is returned with
+%   the additional fields populated.
+
+if nargin < 1 || ~isstruct(params)
+    params = struct();
+end
+
+% Reuse existing utility for core damper quantities
+params = Utils.recompute_damper_params(params);
+
+% Large orifice flow cap (per damper, adjusted for parallels)
+if isfield(params,'orf') && isfield(params.orf,'CdInf') && ...
+        isfield(params,'A_o') && isfield(params,'rho')
+    params.Qcap_big = max(params.orf.CdInf * params.A_o, 1e-9) * ...
+        sqrt(2*1.0e9 / params.rho);
+end
+
+% Minimum laminar damping based on c_lam0
+if isfield(params,'c_lam_min_abs') && isfield(params,'c_lam_min_frac') && ...
+        isfield(params,'c_lam0')
+    params.c_lam_min = max(params.c_lam_min_abs, ...
+        params.c_lam_min_frac * params.c_lam0);
+end
+
+end

--- a/4/GA/compute_metrics_windowed.m
+++ b/4/GA/compute_metrics_windowed.m
@@ -14,9 +14,6 @@ function metr = compute_metrics_windowed(t, x, a_rel, ag, ts, story_height, win,
 %   katın yüksekliğidir. WIN.IDX ilgilenilen pencereyi seçen mantıksal
 %   vektördür. PARAMS yapısal ve damper parametrelerini içerir.
 
-% Türetilmiş damper sabitlerini güncelle
-params = Utils.recompute_damper_params(params);
-
 idx = win.idx;
 
 %% Temel Tepki

--- a/4/GA/export_results.m
+++ b/4/GA/export_results.m
@@ -7,9 +7,6 @@ function export_results(outdir, scaled, params, opts, summary, all_out, varargin
 if nargin < 1 || isempty(outdir), return; end
 if ~exist(outdir,'dir'), mkdir(outdir); end
 
-% Türetilmiş damper sabitlerini güncelle
-params = Utils.recompute_damper_params(params);
-
 %% Meta (IM alanlarını varsayılanlarla doldurma kaldırıldı)
     % TRIM bilgisi opsiyonel
     TRIM_names = Utils.getfield_default(opts,'TRIM_names',{});

--- a/4/GA/run_batch_windowed.m
+++ b/4/GA/run_batch_windowed.m
@@ -16,9 +16,6 @@ if isfield(opts,'order_perm')
     scaled = scaled(opts.order_perm);
 end
 
-% Türetilmiş damper sabitlerini güncelle
-params = Utils.recompute_damper_params(params);
-
 assert(isfield(params,'thermal') && isfield(params.thermal,'hA_W_perK'), ...
     'run_batch_windowed: params.thermal.hA_W_perK eksik');
 

--- a/4/GA/run_one_record_windowed.m
+++ b/4/GA/run_one_record_windowed.m
@@ -24,9 +24,6 @@ function out = run_one_record_windowed(rec, params, opts, prev_ts)
 if nargin < 4, prev_ts = []; end
 if nargin < 3 || isempty(opts), opts = struct(); end
 
-% Türetilmiş damper sabitlerini güncelle
-params = Utils.recompute_damper_params(params);
-
 if isfield(opts,'thermal_reset') && strcmpi(opts.thermal_reset,'cooldown')
     if ~isfield(opts,'cooldown_s') || isempty(opts.cooldown_s) || isnan(opts.cooldown_s)
         opts.cooldown_s = 60;

--- a/4/GA/run_policies_windowed.m
+++ b/4/GA/run_policies_windowed.m
@@ -12,6 +12,8 @@ function P = run_policies_windowed(scaled, params, opts)
 
 %% Girdi ve Varsayılan Ayarlar
 if nargin < 3, opts = struct(); end
+% Derived fields are prepared once
+params = build_params(params);
 if ~isfield(opts,'policies'), opts.policies = {'each','carry','cooldown'}; end
 if ~isfield(opts,'orders'), opts.orders = {'natural','random','worst_first'}; end
 if ~isfield(opts,'cooldown_s_list'), opts.cooldown_s_list = [60 180 300]; end

--- a/4/GA/sdof.m
+++ b/4/GA/sdof.m
@@ -37,7 +37,7 @@ try
     params_tmp = struct('Dp',Dp,'d_w',d_w,'D_m',D_m,'n_turn',n_turn, ...
         'mu_ref',mu_ref,'Lori',Lori,'Lgap',Lgap,'Kd',Kd,'Ebody',Ebody, ...
         'Gsh',Gsh,'orf',struct('d_o',d_o));
-    params_tmp = Utils.recompute_damper_params(params_tmp);
+    params_tmp = build_params(params_tmp);
     Ap    = params_tmp.Ap;
     k_sd  = params_tmp.k_sd;
     c_lam0= params_tmp.c_lam0;


### PR DESCRIPTION
## Summary
- add `build_params` to compute derived damper fields and flow limits once
- stop recomputing parameters in `export_results`, `run_batch_windowed`, `run_one_record_windowed` and `compute_metrics_windowed`
- ensure callers like `parametreler`, `run_policies_windowed`, and GA decoding build the parameter struct up front

## Testing
- `octave -qf --eval "addpath('4/GA'); parametreler; assert(isfield(params,'Ap') && isfield(params,'Qcap_big')); disp(params.Ap);"`
- `octave -qf --eval "addpath('4/GA'); parametreler; [recs_raw, recs]=load_ground_motions(T1); out=run_one_record_windowed(recs(1), params, struct()); disp(out.metr.PFA_top);"` *(fails: 'griddedInterpolant' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c76a6e30408328bb86fbbc666bdc8b