### PR TITLE
Handle parallel pool failures

### DIFF
--- a/4/GA/parpool_hard_reset.m
+++ b/4/GA/parpool_hard_reset.m
@@ -1,6 +1,8 @@
-function parpool_hard_reset(nWorkers)
+function status = parpool_hard_reset(nWorkers)
 % PARPOOL_HARD_RESET parpool'u sıfırlayıp iş parçacıklarını kısıtlar.
 % Eski işleri temizleyerek güvenli bir havuz açılışı sağlar.
+
+status = true;
 
 if nargin<1 || isempty(nWorkers)
     nWorkers = feature('numcores');
@@ -8,15 +10,21 @@ else
     validateattributes(nWorkers, {'numeric'}, {'scalar','integer','positive'});
 end
 
-c = parcluster('Processes');
+try
+    c = parcluster('Processes');
 
-if ~isempty(c.Jobs)
-    delete(c.Jobs);  % çökmüş işleri temizle
-end
+    if ~isempty(c.Jobs)
+        delete(c.Jobs);  % çökmüş işleri temizle
+    end
 
-p = gcp('nocreate');
-if isempty(p) || ~isvalid(p)
-    parpool(c, min(nWorkers, c.NumWorkers));
+    p = gcp('nocreate');
+    if isempty(p) || ~isvalid(p)
+        parpool(c, min(nWorkers, c.NumWorkers));
+    end
+catch ME
+    warning('parpool_hard_reset:Failed', 'Parallel pool could not be opened: %s', ME.message);
+    status = false;
+    return;
 end
 
 pctRunOnAll maxNumCompThreads(1);          % CPU aşırı kullanımını engelle

--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -1,6 +1,12 @@
 function [X,F,gaout] = run_ga_driver(scaled, params, optsEval, optsGA)
 % === Parpool Açılışı (temizlik + iş parçacığı sınırı) ===
-parpool_hard_reset(16);
+usePool = true;
+try
+    usePool = parpool_hard_reset(16);
+catch ME
+    warning('run_ga_driver:parpool', 'Parallel pool unavailable: %s', ME.message);
+    usePool = false;
+end
 %RUN_GA_DRIVER Hibrit GA sürücüsü: önceden hazırlanmış
 % `scaled` veri kümesi ve `params` yapısını kabul eder.
 %   [X,F,GAOUT] = RUN_GA_DRIVER(SCALED, PARAMS, OPTSEVAL, OPTSGA)
@@ -45,7 +51,7 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
        'StallGenLimit',     Utils.getfield_default(optsGA,'StallGenLimit',150), ...
        'DistanceMeasureFcn','distancecrowding', ...
        'OutputFcn',         @(options,state,flag) ga_out_best_pen(options,state,flag, scaled, params, optsEval), ...
-       'UseParallel',       Utils.getfield_default(optsGA,'UseParallel',true), ...
+       'UseParallel',       usePool && Utils.getfield_default(optsGA,'UseParallel',true), ...
        'Display','iter','PlotFcn',[], 'FunctionTolerance',1e-5);
 
     %% Başlangıç Popülasyonu


### PR DESCRIPTION
## Summary
- Prevent `parpool_hard_reset` from crashing by wrapping cluster operations in a try/catch and returning a status flag
- Attempt to start parallel workers in `run_ga_driver` and gracefully continue without them when unavailable
- Disable GA parallelization when a worker pool cannot be opened

## Testing
- `octave -qf --eval "addpath('4/GA'); parpool_hard_reset(1);"`

------
https://chatgpt.com/codex/tasks/task_e_68c7bba889a483288ed77c22502618ed