### PR TITLE
Handle parallel pool failures

### DIFF
--- a/4/GA/parpool_hard_reset.m
+++ b/4/GA/parpool_hard_reset.m
@@ -1,6 +1,8 @@
-function parpool_hard_reset(nWorkers)
+function status = parpool_hard_reset(nWorkers)
 % PARPOOL_HARD_RESET parpool'u sıfırlayıp iş parçacıklarını kısıtlar.
 % Eski işleri temizleyerek güvenli bir havuz açılışı sağlar.
+
+status = true;
 
 if nargin<1 || isempty(nWorkers)
     nWorkers = feature('numcores');
@@ -8,15 +10,21 @@ else
     validateattributes(nWorkers, {'numeric'}, {'scalar','integer','positive'});
 end
 
-c = parcluster('Processes');
+try
+    c = parcluster('Processes');
 
-if ~isempty(c.Jobs)
-    delete(c.Jobs);  % çökmüş işleri temizle
-end
+    if ~isempty(c.Jobs)
+        delete(c.Jobs);  % çökmüş işleri temizle
+    end
 
-p = gcp('nocreate');
-if isempty(p) || ~isvalid(p)
-    parpool(c, min(nWorkers, c.NumWorkers));
+    p = gcp('nocreate');
+    if isempty(p) || ~isvalid(p)
+        parpool(c, min(nWorkers, c.NumWorkers));
+    end
+catch ME
+    warning('parpool_hard_reset:Failed', 'Parallel pool could not be opened: %s', ME.message);
+    status = false;
+    return;
 end
 
 pctRunOnAll maxNumCompThreads(1);          % CPU aşırı kullanımını engelle


### PR DESCRIPTION
## Summary
- Prevent `parpool_hard_reset` from crashing by wrapping cluster operations in a try/catch and returning a status flag
- Attempt to start parallel workers in `run_ga_driver` and gracefully continue without them when unavailable
- Allow `run_ga_driver` to pull `scaled` and `params` from the base workspace when arguments are omitted

## Testing
- `sudo apt-get update` (warned about a 403 proxy but completed)
- `sudo apt-get install -y octave` (failed: ca-certificates-java post-installation script error)
- `octave -qf --eval "addpath('4/GA'); parpool_hard_reset(1);"` (warning: `'parcluster' undefined`, pool not opened)
- `octave -qf --eval "addpath('4/GA'); scaled=struct('IM',1,'PGA',1); params=struct(); try run_ga_driver; catch ME; disp(ME.message); end"` (warning: `'optimoptions' undefined`, confirming input fallback)


------
https://chatgpt.com/codex/tasks/task_e_68c7bba889a483288ed77c22502618ed