### PR TITLE
Allow GA driver to auto prepare inputs

### DIFF
--- a/4/GA/prepare_inputs.m
+++ b/4/GA/prepare_inputs.m
@@ -1,0 +1,27 @@
+function [scaled, params, T1] = prepare_inputs(optsGA)
+%PREPARE_INPUTS Çalışma alanı bağımsız giriş hazırlığı.
+%   [SCALED, PARAMS, T1] = PREPARE_INPUTS(OPTSGA) gerekli yolları ekler,
+%   parametre yapısını oluşturur ve yer hareketi verilerini yükler.
+%   OPTSGA.load_opts varsa load_ground_motions'a iletilir.
+
+if nargin < 1 || isempty(optsGA)
+    optsGA = struct;
+end
+
+% Gerekli yollar için opsiyonel setup çağrısı
+if exist('setup','file') == 2
+    setup;
+end
+
+% Parametreler ve T1 hesapla (script çağrısı fonksiyon kapsamı içinde)
+parametreler;  %#ok<NOPRT>
+
+% Yer hareketi verisini ölçekle
+load_opts = Utils.getfield_default(optsGA, 'load_opts', []);
+if isempty(load_opts)
+    [~, scaled] = load_ground_motions(T1);
+else
+    [~, scaled] = load_ground_motions(T1, load_opts);
+end
+
+end

--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -1,8 +1,21 @@
 function [X,F,gaout] = run_ga_driver(scaled, params, optsEval, optsGA)
-if nargin < 2
-    error('run_ga_driver:input', 'scaled and params are required');
+%RUN_GA_DRIVER Hibrit GA sürücüsü
+%   [X,F,GAOUT] = RUN_GA_DRIVER(SCALED, PARAMS, OPTSEVAL, OPTSGA)
+% `scaled` ve `params` doğrudan argüman olarak verilebilir. Eğer boş
+% bırakılırsa, gerekli veri seti ve parametreler `prepare_inputs` yardımcı
+% fonksiyonu ile hazırlanır.
+
+narginchk(0,4);
+
+if nargin < 1 || isempty(scaled),  scaled  = []; end
+if nargin < 2 || isempty(params),  params  = []; end
+if nargin < 3 || isempty(optsEval), optsEval = struct; end
+if nargin < 4 || isempty(optsGA),   optsGA   = struct; end
+
+% Gerekli girdiler sağlanmadıysa otomatik hazırla
+if isempty(scaled) || isempty(params)
+    [scaled, params] = prepare_inputs(optsGA);
 end
-narginchk(2,4);
 % === Parpool Açılışı (temizlik + iş parçacığı sınırı) ===
 usePool = true;
 try
@@ -11,17 +24,12 @@ catch ME
     warning('run_ga_driver:parpool', 'Parallel pool unavailable: %s', ME.message);
     usePool = false;
 end
-%RUN_GA_DRIVER Hibrit GA sürücüsü: önceden hazırlanmış
-% `scaled` veri kümesi ve `params` yapısını kabul eder.
+%RUN_GA_DRIVER Hibrit GA sürücüsü: önceden hazırlanmış `scaled` veri kümesi
+% ve `params` yapısını kabul eder.
 %   [X,F,GAOUT] = RUN_GA_DRIVER(SCALED, PARAMS, OPTSEVAL, OPTSGA)
-% `scaled` ve `params` çalışma alanında hazır olmalı veya dışarıda bir
-% hazırlık fonksiyonu tarafından sağlanmalıdır. Uygunluk hesapları sırasında
-% IO yapılmaz; yeniden ölçekleme yoktur.
-
-%% Girdi Çözümleme
-% `scaled` ve `params` doğrudan argüman olarak alınır.
-if nargin < 3 || isempty(optsEval), optsEval = struct; end
-if nargin < 4 || isempty(optsGA),   optsGA   = struct; end
+% `scaled` veya `params` boş bırakılırsa `prepare_inputs` devreye girer ve
+% gerekli verileri oluşturur. Uygunluk hesapları sırasında IO yapılmaz;
+% yeniden ölçekleme yoktur.
 
 meta = struct('thr', Utils.default_qc_thresholds(struct()));
 


### PR DESCRIPTION
## Summary
- Allow `run_ga_driver` to run without arguments by auto-preparing required data via `prepare_inputs`.
- Provide new `prepare_inputs` helper to compute parameters and scaled ground motions without relying on the base workspace.

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b63a88888328910a4da95bebc846