### PR TITLE
Remove export/quiet flags from GA evaluation

### DIFF
--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -37,8 +37,6 @@ assert(~isempty(scaled), 'run_ga_driver: scaled dataset is empty.');
 assert(~isempty(params), 'run_ga_driver: params is empty.');
 
 % ---------- Varsayılan değerlendirme ayarları (IO yok) ----------
-optsEval.do_export     = false;
-optsEval.quiet         = true;
 optsEval.thr = Utils.default_qc_thresholds(Utils.getfield_default(optsEval,'thr', meta.thr));
 %% GA Kurulumu
 % GA amaç fonksiyonu ve optimizasyon seçeneklerini hazırla.
@@ -153,7 +151,7 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
     rel = @(v,lim) max(0,(v - lim)./max(lim,eps)).^pwr;
     rev = @(v,lim) max(0,(lim - v)./max(lim,eps)).^pwr;
 
-    Opost = struct('do_export',false,'quiet',true, 'thr', meta.thr);
+    Opost = struct('thr', meta.thr);
 
     parfor i = 1:nF
         Xi = quant_clamp_x(X(i,:));
@@ -354,8 +352,6 @@ function [f, meta] = eval_design_fast(x, scaled, params_base, optsEval)
 
     O = struct();
     if nargin >= 4 && ~isempty(optsEval), O = optsEval; end
-    O.do_export = false;
-    O.quiet  = true;
     % policy/order vars referenced by run_batch_windowed default to each/natural
 
     % Güvenli değerlendirme (GA sırasında IO yok)

--- a/4/GA/run_policies_windowed.m
+++ b/4/GA/run_policies_windowed.m
@@ -21,11 +21,16 @@ if ~isfield(opts,'rng_seed'), opts.rng_seed = 42; end
 if ~isfield(opts,'rank_metric'), opts.rank_metric = 'E_orifice_win'; end
 
 % Sessizlik/çıktı bayrakları ve çıktı dizini
-quiet = isfield(opts,'quiet') && opts.quiet;
-% Politika koşuları için varsayılan olarak sonuçlar dışa aktarılır
-do_export = ~isfield(opts,'do_export') || opts.do_export;
-ts = datestr(now,'yyyymmdd_HHMMSS_FFF'); outdir = fullfile('out', ts);
-if ~exist(outdir,'dir'), mkdir(outdir); end
+quiet = ~isfield(opts,'quiet') || opts.quiet;
+% Politika koşuları için varsayılan olarak sonuçlar dışa aktarılmaz
+do_export = isfield(opts,'do_export') && opts.do_export;
+if do_export
+    ts = datestr(now,'yyyymmdd_HHMMSS_FFF');
+    outdir = fullfile('out', ts);
+    if ~exist(outdir,'dir'), mkdir(outdir); end
+else
+    outdir = '';
+end
 
 % Konsol başlığı
 


### PR DESCRIPTION
## Summary
- Drop manual `do_export` and `quiet` fields in GA driver
- Default policy runner to silent, non-exporting mode when flags absent

## Testing
- `octave -qf --eval "addpath('4/GA'); run_ga_driver;"` *(fails: 'griddedInterpolant' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cec270bc8328a889fbf07f4b4a37