### PR TITLE
Vectorize seed bound enforcement

### DIFF
--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -83,9 +83,7 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
                 seed = [seed, 0.75*ones(size(seed,1), size(P0,2)-size(seed,2))];
             end
             % Tohumları güvenli aralığa sıkıştır (lb/ub)
-            for si = 1:size(seed,1)
-                seed(si,:) = max(min(seed(si,:), ub), lb);
-            end
+            seed = max(min(seed, ub), lb);
             ns = min(size(seed,1), size(P0,1));
             P0(1:ns,:) = seed(1:ns,:);
             % Önceki Pareto'yu kullanmak için en son ga_front.csv dosyasını okumayı dene


### PR DESCRIPTION
## Summary
- Remove per-row loop in seed bounding and replace with vectorized max/min

## Testing
- `which octave` (missing)
- `apt-get install -y octave` *(fails: operation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d35239bc8328873c09846b35a977