### PR TITLE
Remove unused dPq95w metric

### DIFF
--- a/4/GA/run_ga_driver.m
+++ b/4/GA/run_ga_driver.m
@@ -107,7 +107,7 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
     dP95   = zeros(nF,1);  Qcap95 = zeros(nF,1); cavW = zeros(nF,1);
     Tend   = zeros(nF,1);  muend  = zeros(nF,1);
     PFp95  = zeros(nF,1);  Qq50 = zeros(nF,1);  Qq95 = zeros(nF,1);
-    dPq50  = zeros(nF,1);  dPq95w = zeros(nF,1); Toil = nan(nF,1); Tsteel = nan(nF,1);
+    dPq50  = zeros(nF,1);  Toil = nan(nF,1); Tsteel = nan(nF,1);
     Etot   = zeros(nF,1);  Eor = zeros(nF,1);   Estr  = zeros(nF,1); Eratio = zeros(nF,1); Pmech = zeros(nF,1);
     PFAw   = zeros(nF,1);  IDRw  = zeros(nF,1);
 
@@ -167,7 +167,6 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
         Qq50(i)   = max(v_Qq50(:));
         Qq95(i)   = max(v_Qq95(:));
         dPq50(i)  = max(v_dPq50(:));
-        dPq95w(i) = max(v_dP95(:));
         Toil(i)   = max(tg(Si.table,'T_oil_end',NaN));
         Tsteel(i) = max(tg(Si.table,'T_steel_end',NaN));
 
@@ -210,7 +209,6 @@ ub = [3.0,8, 0.90, 5, 0.90, 1.00, 1.50, 200, 600, 240, 16, 160, 18, 2.00, 3];
     T.dP95          = dP95;     T.Qcap95      = Qcap95;   T.cav_pct = cavW;
     T.T_end         = Tend;     T.mu_end      = muend;    T.PF_p95  = PFp95;
     T.Q_q50         = Qq50;     T.Q_q95       = Qq95;     T.dP50 = dPq50;
-    T.dP_orf_q95    = dPq95w;
     if ~isempty(Toil),   T.T_oil_end   = Toil;   end
     if ~isempty(Tsteel), T.T_steel_end = Tsteel; end
     T.energy_tot_sum      = Etot;     T.E_orifice_sum     = Eor;      T.E_struct_sum  = Estr;


### PR DESCRIPTION
## Summary
- Drop redundant `dPq95w` array from GA driver and associated `dP_orf_q95` table column.

## Testing
- `matlab -batch "checkcode('run_ga_driver.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e55106e883289460ea6b9d894e60