### PR TITLE
refactor: consolidate field assignments

### DIFF
--- a/4/GA/korelasyon.m
+++ b/4/GA/korelasyon.m
@@ -240,10 +240,9 @@ if opt.Verbose
 end
 
 % 9) Çıktı paketleme
-S = struct();
-S.T = T_use; S.R_pearson = R_pearson; S.P_pearson = P_pearson;
-S.R_spearman = R_spear; S.P_spearman = P_spear;
-S.partial = partial; S.lm = lm; S.ens = ens; S.figs = figs;
+S = struct('T', T_use, 'R_pearson', R_pearson, 'P_pearson', P_pearson, ...
+    'R_spearman', R_spear, 'P_spearman', P_spear, ...
+    'partial', partial, 'lm', lm, 'ens', ens, 'figs', figs);
 
 %% 10) CSV çıktılarını yaz
 try

--- a/4/GA/load_ground_motions.m
+++ b/4/GA/load_ground_motions.m
@@ -153,9 +153,7 @@ if nargin >= 1 && ~isempty(T1)
     end
     fprintf('\n');
 
-    meta.IM_mode  = IM_mode;
-    meta.band_fac = band_fac;
-    meta.s_bounds = s_bounds;
+    meta = struct('IM_mode', IM_mode, 'band_fac', band_fac, 's_bounds', s_bounds);
     if exist('dropped','var'), meta.TRIM_names = dropped; else, meta.TRIM_names = {}; end
 end
 end

--- a/4/GA/mck_with_damper.m
+++ b/4/GA/mck_with_damper.m
@@ -102,19 +102,9 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
     F(:,Mvec) = F(:,Mvec) + F_story;
     a_rel = ( -(M\(C*v.' + K*x.' + F.')).' - ag.*r.' );
 
-    ts = struct();
-    ts.dvel = dvel;
-    ts.story_force = F_story;
-    ts.Q = Q;
-    ts.dP_orf = dP_orf;
-    ts.PF = F_p;
-    ts.cav_mask = dP_orf < 0;
-    ts.P_sum = P_sum;
-    ts.E_orf = E_orf;
-    ts.E_struct = E_struct;
-    ts.T_oil = T_o;
-    ts.mu = mu;
-    ts.c_lam = c_lam;
+    ts = struct('dvel', dvel, 'story_force', F_story, 'Q', Q, ...
+        'dP_orf', dP_orf, 'PF', F_p, 'cav_mask', dP_orf < 0, 'P_sum', P_sum, ...
+        'E_orf', E_orf, 'E_struct', E_struct, 'T_oil', T_o, 'mu', mu, 'c_lam', c_lam);
 
 %% İç Fonksiyonlar
     function Fd = dev_force(tt,x_,v_,c_lam_loc,mu_abs_loc)

--- a/4/GA/parametreler.m
+++ b/4/GA/parametreler.m
@@ -58,16 +58,15 @@ rho   = 850;       % Yağ yoğunluğu [kg/m^3]
 n_orf = 6;         % Kat başına orifis sayısı
 
 % Orifis katsayıları
-orf = struct();
-orf.Cd0   = 0.61;                    % Re → 0 limitindeki boşalım katsayısı
-orf.CdInf = 0.80;                    % Yüksek Re için boşalım katsayısı
-orf.Rec   = 3000;                    % Kritik Reynolds sayısı
-orf.p_exp = 1.1;                     % Geçiş eğrisinin eğimi
-orf.p_amb = 1.0e5;                   % Ortam basıncı [Pa]
-orf.p_cav_eff = 2.0e3;               % Etkin kavitasyon eşiği [Pa]
-orf.cav_sf    = 0.90;                % Kavitasyon emniyet katsayısı
-orf.d_o   = d_o;                     % Re düzeltmesi için çap [m]
-orf.veps  = 0.10;                    % Düşük hız yumuşatma [m/s]
+orf = struct('Cd0', 0.61, ...        % Re → 0 limitindeki boşalım katsayısı
+             'CdInf', 0.80, ...      % Yüksek Re için boşalım katsayısı
+             'Rec', 3000, ...        % Kritik Reynolds sayısı
+             'p_exp', 1.1, ...       % Geçiş eğrisinin eğimi
+             'p_amb', 1.0e5, ...     % Ortam basıncı [Pa]
+             'p_cav_eff', 2.0e3, ... % Etkin kavitasyon eşiği [Pa]
+             'cav_sf', 0.90, ...     % Kavitasyon emniyet katsayısı
+             'd_o', d_o, ...         % Re düzeltmesi için çap [m]
+             'veps', 0.10);          % Düşük hız yumuşatma [m/s]
 
 
 % Termal model parametreleri

--- a/4/GA/run_batch_windowed.m
+++ b/4/GA/run_batch_windowed.m
@@ -140,25 +140,14 @@ function summary = build_summary_table(vars, opts)
 %BUILD_SUMMARY_TABLE Hesaplanan metrikleri tabloya dönüştür ve QC uygula
 summary = struct();
 
-summary.table = table(vars.names, vars.scale, vars.SaT1, vars.t5, vars.t95, vars.coverage, vars.policy_col, vars.order_col, vars.cooldown_col, ...
-    vars.PFA, vars.IDR, vars.dP95, vars.Qcap95, vars.cav_pct, vars.zeta1_hot, vars.z2_over_z1_hot, vars.P_mech, vars.Re_max, ...
-    vars.Q_q95, vars.Q_q50, vars.dP50, vars.x10_max_D, vars.a10abs_max_D, vars.E_orifice, vars.E_struct, vars.E_ratio, vars.qc_pass, ...
-    vars.T_start, vars.T_end, vars.mu_end, vars.clamp_hits, vars.Dp_mm_col, vars.mu_ref_col, ...
-    'VariableNames', {'name','scale','SaT1','t5','t95','coverage','policy','order','cooldown_s', ...
-    'PFA','IDR','dP95','Qcap95','cav_pct','zeta1_hot','z2_over_z1_hot','P_mech','Re_max', ...
-    'Q_q95','Q_q50','dP50','x10_max_D','a10abs_max_D','E_orifice','E_struct','E_ratio','qc_pass', ...
-    'T_start','T_end','mu_end','clamp_hits','Dp_mm','mu_ref'});
-
-summary.all_out = vars.all_out;
-
 thr = opts.thr;
-ok_T    = summary.table.T_end   <= thr.T_end_max;
-ok_mu   = summary.table.mu_end  >= thr.mu_end_min;
-ok_dP   = summary.table.dP95    <= thr.dP95_max;
-ok_Qcap = summary.table.Qcap95  <  thr.Qcap95_max;
-ok_cav  = summary.table.cav_pct == 0;
-qc_reason = strings(height(summary.table),1);
-for r = 1:height(summary.table)
+ok_T    = vars.T_end   <= thr.T_end_max;
+ok_mu   = vars.mu_end  >= thr.mu_end_min;
+ok_dP   = vars.dP95    <= thr.dP95_max;
+ok_Qcap = vars.Qcap95  <  thr.Qcap95_max;
+ok_cav  = vars.cav_pct == 0;
+qc_reason = strings(numel(vars.names),1);
+for r = 1:numel(vars.names)
     bad = {};
     if ~ok_T(r),    bad{end+1}='T';  end %#ok<AGROW>
     if ~ok_mu(r),   bad{end+1}='mu'; end %#ok<AGROW>
@@ -167,11 +156,17 @@ for r = 1:height(summary.table)
     if ~ok_cav(r),  bad{end+1}='cav'; end %#ok<AGROW>
     qc_reason(r) = strjoin(bad,',');
 end
-summary.table.ok_T = ok_T;
-summary.table.ok_mu = ok_mu;
-summary.table.ok_dP = ok_dP;
-summary.table.ok_Qcap = ok_Qcap;
-summary.table.ok_cav = ok_cav;
-summary.table.qc_reason = qc_reason;
+
+summary.table = table(vars.names, vars.scale, vars.SaT1, vars.t5, vars.t95, vars.coverage, vars.policy_col, vars.order_col, vars.cooldown_col, ...
+    vars.PFA, vars.IDR, vars.dP95, vars.Qcap95, vars.cav_pct, vars.zeta1_hot, vars.z2_over_z1_hot, vars.P_mech, vars.Re_max, ...
+    vars.Q_q95, vars.Q_q50, vars.dP50, vars.x10_max_D, vars.a10abs_max_D, vars.E_orifice, vars.E_struct, vars.E_ratio, vars.qc_pass, ...
+    vars.T_start, vars.T_end, vars.mu_end, vars.clamp_hits, vars.Dp_mm_col, vars.mu_ref_col, ...
+    ok_T, ok_mu, ok_dP, ok_Qcap, ok_cav, qc_reason, ...
+    'VariableNames', {'name','scale','SaT1','t5','t95','coverage','policy','order','cooldown_s', ...
+    'PFA','IDR','dP95','Qcap95','cav_pct','zeta1_hot','z2_over_z1_hot','P_mech','Re_max', ...
+    'Q_q95','Q_q50','dP50','x10_max_D','a10abs_max_D','E_orifice','E_struct','E_ratio','qc_pass', ...
+    'T_start','T_end','mu_end','clamp_hits','Dp_mm','mu_ref','ok_T','ok_mu','ok_dP','ok_Qcap','ok_cav','qc_reason'});
+
+summary.all_out = vars.all_out;
 end
 

--- a/4/GA/run_one_record_windowed.m
+++ b/4/GA/run_one_record_windowed.m
@@ -34,7 +34,6 @@ end
 % QC eşikleri (eksik alanlar varsayılanlarla doldurulur)
 if ~isfield(opts,'thr'), opts.thr = struct(); end
 thr = Utils.default_qc_thresholds(opts.thr);
-opts.thr = thr;
 
 assert(isfield(params,'thermal') && isfield(params.thermal,'hA_W_perK'), ...
     'run_one_record_windowed: params.thermal.hA_W_perK eksik');
@@ -166,25 +165,14 @@ else
 end
 
 %% Çıktıların Derlenmesi
-out = struct();
-out.name  = rec.name;
-out.scale = Utils.getfield_default(rec,'scale',1);
-out.SaT1  = Utils.getfield_default(rec,'IM',NaN);
-out.win   = win;
-out.metr  = metr;
-out.ts = ts;
-out.qc_pass = qc_pass;
-out.T_start = T_start;
-out.T_end = T_end;
-out.mu_end = mu_end;
-out.clamp_hits = clamp_hits;
-% kolaylık amaçlı telemetri alanları
-out.PFA  = metr.PFA;
-out.IDR  = metr.IDR;
-out.dP95 = metr.dP95;
-out.Qcap95 = metr.Qcap95;
-out.cav_pct = metr.cav_pct;
-out.t5 = win.t5; out.t95 = win.t95; out.coverage = win.coverage;
+out = struct('name', rec.name, ...
+    'scale', Utils.getfield_default(rec,'scale',1), ...
+    'SaT1', Utils.getfield_default(rec,'IM',NaN), ...
+    'win', win, 'metr', metr, 'ts', ts, 'qc_pass', qc_pass, ...
+    'T_start', T_start, 'T_end', T_end, 'mu_end', mu_end, ...
+    'clamp_hits', clamp_hits, ...
+    'PFA', metr.PFA, 'IDR', metr.IDR, 'dP95', metr.dP95, 'Qcap95', metr.Qcap95, ...
+    'cav_pct', metr.cav_pct, 't5', win.t5, 't95', win.t95, 'coverage', win.coverage);
 % ayarlanmışsa PF rampasının başlangıcı
 try
     if isfield(params,'cfg') && isfield(params.cfg,'PF')

--- a/4/GA/run_policies_windowed.m
+++ b/4/GA/run_policies_windowed.m
@@ -39,7 +39,7 @@ base_opts = opts; base_opts.thermal_reset = 'each'; base_opts.order = 'natural';
 [base_summary, base_all] = run_batch_windowed(scaled, params, base_opts);
 basePFA_mean = mean(base_summary.table.PFA);
 baseIDR_mean = mean(base_summary.table.IDR);
-baseTend_max = max(base_summary.table.T_end);
+base_T_end_max = max(base_summary.table.T_end);
 base_dP95_max = max(base_summary.table.dP95);
 base_Qcap95_max = max(base_summary.table.Qcap95);
 base_cav_max = max(base_summary.table.cav_pct);
@@ -48,7 +48,7 @@ base_qc_pass = sum(base_summary.table.qc_pass);
 base_qc_n = height(base_summary.table);
 
 orders_struct = compute_orders(opts, scaled, base_all);
-base_metrics = struct('PFA_mean', basePFA_mean, 'IDR_mean', baseIDR_mean, 'T_end_max', baseTend_max);
+base_metrics = struct('PFA_mean', basePFA_mean, 'IDR_mean', baseIDR_mean, 'T_end_max', base_T_end_max);
 P = run_combinations(scaled, params, opts, orders_struct, base_metrics);
 end
 
@@ -105,10 +105,10 @@ for ip = 1:numel(opts.policies)
 
             curPFA_mean = mean(summary.table.PFA);
             curIDR_mean = mean(summary.table.IDR);
-            curTend_max = max(summary.table.T_end);
+            cur_T_end_max = max(summary.table.T_end);
             deltas = struct('PFA', curPFA_mean - base_metrics.PFA_mean, ...
                             'IDR', curIDR_mean - base_metrics.IDR_mean, ...
-                            'T_end', curTend_max - base_metrics.T_end_max);
+                            'T_end', cur_T_end_max - base_metrics.T_end_max);
 
             report_combination(pol, ord, cdval, summary, deltas, qc, base_metrics);
 


### PR DESCRIPTION
## Summary
- pre-compute QC flags and inline them in GA batch summary table
- build output and telemetry structs in a single call to drop self-assignments
- standardize field names and metadata across policy and correlation scripts

## Testing
- `octave -qf --eval "addpath('4/GA'); [X,F,gaout]=run_ga_driver();"` *(fails: command not found)*
- `apt-get install -y octave` *(fails: Unable to locate package octave)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f2ab4bc083288abc4bd9c090c6bd