### PR TITLE
Refine GA driver and windowed workflows

### DIFF
--- a/4/GA/run_policies_windowed.m
+++ b/4/GA/run_policies_windowed.m
@@ -63,7 +63,7 @@ end
 
 function P = run_combinations(scaled, params, opts, orders_struct, base_metrics)
 %RUN_COMBINATIONS Politika-sıra kombinasyonlarını değerlendirir
-P = struct('policy',{},'order',{},'cooldown_s',{},'summary',{},'qc',{},'deltas',{});
+P = struct('policy',{},'order',{},'cooldown_s',{},'summary',{},'deltas',{});
 for ip = 1:numel(opts.policies)
     pol = opts.policies{ip};
     for io = 1:numel(opts.orders)
@@ -83,9 +83,6 @@ for ip = 1:numel(opts.policies)
             if strcmp(pol,'cooldown'), run_opts.cooldown_s = cdval; end
             [summary, ~] = run_batch_windowed(scaled, params, run_opts);
 
-            qc.pass_fraction = mean(summary.table.qc_pass);
-            qc.n = height(summary.table);
-
             curPFA_mean = mean(summary.table.PFA);
             curIDR_mean = mean(summary.table.IDR);
             cur_T_end_max = max(summary.table.T_end);
@@ -94,7 +91,7 @@ for ip = 1:numel(opts.policies)
                             'T_end', cur_T_end_max - base_metrics.T_end_max);
 
             P(end+1) = struct('policy',pol,'order',ord,'cooldown_s',cdval, ...
-                'summary',summary.table,'qc',qc,'deltas',deltas); %#ok<AGROW>
+                'summary',summary.table,'deltas',deltas); %#ok<AGROW>
         end
     end
 end


### PR DESCRIPTION
## Summary
- simplify evaluation threshold handling in the GA driver and drop the saved meta wrapper
- guard PF auto timing with explicit field checks and remove the try/catch in the windowed record runner while tightening the mu-floor and PF metadata guards
- drop policy QC counters and rely on direct table access when summarising metrics
- replace try/catch wrappers in the windowed metrics computation with explicit structure/field checks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94264af408328ba1a7afb056d779d