### PR TITLE
Refine GA driver setup and clean artifacts

### DIFF
--- a/4/GA/run_batch_windowed.m
+++ b/4/GA/run_batch_windowed.m
@@ -63,9 +63,10 @@ vars.zeta1_hot       = zeros(n,1);
 vars.z2_over_z1_hot  = zeros(n,1);
 vars.P_mech_sum      = zeros(n,1);
 vars.Re_max      = zeros(n,1);
-vars.Q_q95  = zeros(n,1);
-vars.Q_q50  = zeros(n,1);
-vars.dP50   = zeros(n,1);
+    vars.Q_q95  = zeros(n,1);
+    vars.Q_q50  = zeros(n,1);
+    vars.dP50   = zeros(n,1);
+    vars.PF_p95 = zeros(n,1);
 vars.x10_max_damperli = zeros(n,1);
 vars.a10abs_max_damperli = zeros(n,1);
 vars.E_orifice_sum = zeros(n,1);
@@ -119,6 +120,7 @@ for k = 1:numel(scaled)
     vars.Q_q95(k)  = Utils.getfield_default(m_nom,'Q_q95',NaN);
     vars.Q_q50(k)  = Utils.getfield_default(m_nom,'Q_q50',NaN);
     vars.dP50(k)   = Utils.getfield_default(m_nom,'dP50',NaN);
+    vars.PF_p95(k) = Utils.getfield_default(m_nom,'PF_p95',NaN);
     vars.x10_max_damperli(k) = Utils.getfield_default(m_nom,'x10_max_damperli',NaN);
     vars.a10abs_max_damperli(k) = Utils.getfield_default(m_nom,'a10abs_max_damperli',NaN);
     vars.E_orifice_sum(k) = Utils.getfield_default(m_nom,'E_orifice_sum',NaN);
@@ -160,12 +162,12 @@ for r = 1:numel(vars.names)
 end
 
 summary.table = table(vars.names, vars.scale, vars.SaT1, vars.t5, vars.t95, vars.coverage, vars.policy_col, vars.order_col, vars.cooldown_col, ...
-    vars.PFA, vars.IDR, vars.dP95, vars.Qcap95, vars.cav_pct, vars.zeta1_hot, vars.z2_over_z1_hot, vars.P_mech_sum, vars.Re_max, ...
+    vars.PFA, vars.IDR, vars.dP95, vars.Qcap95, vars.cav_pct, vars.PF_p95, vars.zeta1_hot, vars.z2_over_z1_hot, vars.P_mech_sum, vars.Re_max, ...
     vars.Q_q95, vars.Q_q50, vars.dP50, vars.x10_max_damperli, vars.a10abs_max_damperli, vars.E_orifice_sum, vars.E_struct_sum, vars.energy_tot_sum, vars.E_ratio, vars.qc_pass, ...
     vars.T_start, vars.T_end, vars.mu_end, vars.clamp_hits, vars.Dp_mm_col, vars.mu_ref_col, ...
     ok_T, ok_mu, ok_dP, ok_Qcap, ok_cav, qc_reason, ...
     'VariableNames', {'name','scale','SaT1','t5','t95','coverage','policy','order','cooldown_s', ...
-    'PFA','IDR','dP95','Qcap95','cav_pct','zeta1_hot','z2_over_z1_hot','P_mech_sum','Re_max', ...
+    'PFA','IDR','dP95','Qcap95','cav_pct','PF_p95','zeta1_hot','z2_over_z1_hot','P_mech_sum','Re_max', ...
     'Q_q95','Q_q50','dP50','x10_max_damperli','a10abs_max_damperli','E_orifice_sum','E_struct_sum','energy_tot_sum','E_ratio','qc_pass', ...
     'T_start','T_end','mu_end','clamp_hits','Dp_mm','mu_ref','ok_T','ok_mu','ok_dP','ok_Qcap','ok_cav','qc_reason'});
 


### PR DESCRIPTION
## Summary
- update GA decision bounds and reseed initial population to match the current 15D design space
- refactor evaluation bookkeeping with reusable helpers, remove the unused memo_store cache and return optional simulation details
- streamline baseline row generation to reuse GA metrics without re-running the simulation and add dataset signature helper
- include PF_p95 in batch summaries so Pareto exports retain the computed percentile instead of falling back to zero

## Testing
- not run (MATLAB environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68c91ae3cbcc832892a9803272f99956