### PR TITLE
Remove laminar PF coupling and update diagnostics

### DIFF
--- a/sdof.m
+++ b/sdof.m
@@ -618,7 +618,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     end
     params_orf = struct('Ap',Ap,'Qcap',Qcap_eff,'orf',orf_loc,'rho',rho,...
                         'Ao',Ao,'mu',mu_abs,'F_lin',F_lin,'Lori',Lori);
-    [F_orf, dP_orf, Q, P_orf_per] = calc_orifice_force_local(dvel, params_orf);
+    [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force_local(dvel, params_orf);
 
     qmag_loc = Qcap_eff * tanh( (Ap/Qcap_eff) * sqrt(dvel.^2 + orf.veps^2) );
     Re_loc   = (rho .* qmag_loc .* max(orf.d_o,1e-9)) ./ max(Ao*mu_abs,1e-9);
@@ -630,7 +630,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     dP_cav_loc= max( (p_up_loc - orf.p_cav_eff).*orf.cav_sf, 0 );
     F_p = F_lin + F_orf;
 
-    dp_pf = (c_lam*dvel + (F_p - k_sd*drift)) ./ Ap;
+    dp_pf = (F_p - k_sd*drift) ./ Ap;
     if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
         s = tanh(20*dvel);
         dp_pf = s .* max(0, s .* dp_pf);
@@ -639,8 +639,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     F_p = k_sd*drift + (w_pf_vec .* dp_pf) * Ap;
 
     F_story = F_p;
-    P_visc_per = c_lam * (dvel.^2);
-    P_sum = sum( (P_visc_per + P_orf_per) .* multi, 2 );
+    P_sum = sum( (P_lam_per + P_orf_per) .* multi, 2 );
     P_orf_tot = sum(P_orf_per .* multi, 2);
     P_struct_tot = sum(F_story .* dvel, 2);
     E_orf = cumtrapz(t, P_orf_tot);
@@ -675,7 +674,8 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
 
     ts = struct('dvel', dvel, 'story_force', F_story, 'Q', Q, ...
         'dP_orf', dP_orf, 'PF', F_p, 'cav_mask', dP_orf < 0, 'P_sum', P_sum, ...
-        'E_orf', E_orf, 'E_struct', E_struct, 'T_oil', T_o, 'mu', mu, 'c_lam', c_lam);
+        'E_orf', E_orf, 'E_struct', E_struct, 'T_oil', T_o, 'mu', mu, ...
+        'c_lam', c_lam, 'P_lam', P_lam_per);
 
     function Fd = dev_force(tt,x_,v_,c_lam_loc,mu_abs_loc)
         drift_ = x_(Mvec) - x_(Nvec);
@@ -683,8 +683,8 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
         F_lin_ = k_sd*drift_;
         params_loc = struct('Ap',Ap,'Qcap',Qcap,'orf',orf,'rho',rho,...
                         'Ao',Ao,'mu',mu_abs_loc,'F_lin',F_lin_,'Lori',Lori);
-        [F_orf_, ~, ~, ~] = calc_orifice_force_local(dvel_, params_loc);
-        dp_pf_ = (c_lam_loc*dvel_ + F_orf_) ./ Ap;
+        [~, dP_orf_, ~, ~, ~] = calc_orifice_force_local(dvel_, params_loc);
+        dp_pf_ = dP_orf_;
         if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
             s = tanh(20*dvel_);
             dp_pf_ = s .* max(0, s .* dp_pf_);
@@ -698,27 +698,42 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     end
 end
 
-function [F_orf, dP_orf, Q, P_orf_per] = calc_orifice_force_local(dvel, params)
+function [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force_local(dvel, params)
     qmag = params.Qcap * tanh( (params.Ap/params.Qcap) * sqrt(dvel.^2 + params.orf.veps^2) );
-    Re   = (params.rho .* qmag .* max(params.orf.d_o,1e-9)) ./ max(params.Ao*params.mu,1e-9);
+    sgn  = dvel ./ sqrt(dvel.^2 + params.orf.veps^2);
+    Q    = qmag .* sgn;
+
+    d_o  = max(getfield_default_local(params.orf,'d_o',0), 1e-9);
+    Re   = (params.rho .* abs(Q) .* d_o) ./ max(params.Ao*params.mu,1e-9);
     Cd0   = params.orf.Cd0;
     CdInf = params.orf.CdInf;
     p_exp = params.orf.p_exp;
-    Rec   = params.orf.Rec;
-    Cd    = CdInf - (CdInf - Cd0) ./ (1 + (Re./max(Rec,1)).^p_exp);
+    Rec   = max(params.orf.Rec, 1);
+    Cd    = CdInf - (CdInf - Cd0) ./ (1 + (Re./Rec).^p_exp);
     Cd    = max(min(Cd, 1.2), 0.2);
 
-    dP_kv  = 0.5*params.rho .* ( qmag ./ max(Cd.*params.Ao,1e-12) ).^2;
+    RQ    = params.rho ./ max(2 * (Cd .* params.Ao).^2, 1e-18);
+    dP_kv = RQ .* Q .* abs(Q);
+
+    n_orf = getfield_default_local(params.orf, 'n_orf', 1);
+    nd    = getfield_default_local(params, 'n_parallel', getfield_default_local(params, 'nd', 1));
+    denom = max(1, nd * n_orf);
+    R_lam = (128 * params.mu .* params.Lori ./ (pi * d_o.^4)) / denom;
+    dP_lam = R_lam .* Q;
+    dP_h   = dP_lam + dP_kv;
+
     p_up   = params.orf.p_amb + abs(params.F_lin)./max(params.Ap,1e-12);
     dP_cav = max( (p_up - params.orf.p_cav_eff).*params.orf.cav_sf, 0 );
     epsm = 1e5;
     if isfield(params,'orf') && isfield(params.orf,'softmin_eps') && isfinite(params.orf.softmin_eps)
         epsm = params.orf.softmin_eps;
     end
-    dP_orf = softmin_local(dP_kv, dP_cav, epsm);
-    sgn = dvel ./ sqrt(dvel.^2 + params.orf.veps^2);
-    F_orf = dP_orf .* params.Ap .* sgn;
+    dP_orf_mag = softmin_local(abs(dP_h), dP_cav, epsm);
 
-    Q = qmag;
-    P_orf_per = dP_kv .* qmag;
+    dP_orf = dP_orf_mag .* sgn;
+    F_orf  = dP_orf .* params.Ap;
+
+    P_orf_per = dP_orf_mag .* abs(Q);
+    P_lam_per = dP_lam .* Q;
+    P_lam_per = max(P_lam_per, 0);
 end


### PR DESCRIPTION
## Summary
- drop the laminar dashpot contribution from the PF pressure path and derive it directly from the orifice drop
- replace the obsolete viscous power diagnostic with a laminar power trace based on dP_lam .* Q and expose it in the time series
- mirror the same PF and diagnostic updates inside the SDOF helper implementation

## Testing
- Not run (MATLAB/Octave not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9b195603883289d213fb765606519