### PR TITLE
Split laminar and kv orifice power tracking

### DIFF
--- a/viskoz.m
+++ b/viskoz.m
@@ -1299,7 +1299,7 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
     end
     params = struct('Ap',Ap,'Qcap',Qcap_eff,'orf',orf_loc,'rho',rho,...
                     'Ao',Ao,'mu',mu_abs,'F_lin',F_lin,'Lori',Lori);
-    [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force(dvel, params);
+    [F_orf, dP_orf, Q, P_orf_per, P_lam_per, P_kv_per] = calc_orifice_force(dvel, params);
     % Ek diagnostikler: dP_kv ve dP_cav (kv ve kavitasyon limitleri)
     qmag_loc = Qcap_eff * tanh( (Ap/Qcap_eff) * sqrt(dvel.^2 + orf.veps^2) );
     Re_loc   = (rho .* qmag_loc .* max(orf.d_o,1e-9)) ./ max(Ao*mu_abs,1e-9);
@@ -1321,12 +1321,10 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
 
     % Geometri ölçeklendirmesi R sadece montajda uygulanır
     F_story = F_p;
-    % Orifice dissipation already includes the laminar component; split it so
-    % that the thermal power sum does not double count the laminar estimate.
-    P_lam_share = min(P_lam_per, P_orf_per);
-    P_kv_per = max(P_orf_per - P_lam_share, 0);
-    P_orf_net_per = P_lam_share + P_kv_per;
-    P_sum = sum(P_orf_net_per .* multi, 2);
+    % Toplam orifis gücünü laminer ve kv bileşenleri olarak ayır ve ısı
+    % birikiminde bu iki parçanın toplamını kullan.
+    P_orf_net_per = P_lam_per + P_kv_per;
+    P_sum = sum((P_lam_per + P_kv_per) .* multi, 2);
     P_orf_tot = sum(P_orf_net_per .* multi, 2);
     % Yapısal güç kat toplam kuvvetini kullanır; ekstra çarpan kullanılmaz
     P_struct_tot = sum(F_story .* dvel, 2);
@@ -1377,7 +1375,7 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         F_lin_ = k_sd*drift_;
         params = struct('Ap',Ap,'Qcap',Qcap,'orf',orf,'rho',rho,...
                         'Ao',Ao,'mu',mu_abs_loc,'F_lin',F_lin_,'Lori',Lori);
-        [~, dP_orf_, ~, ~, ~] = calc_orifice_force(dvel_, params);
+        [~, dP_orf_, ~, ~, ~, ~] = calc_orifice_force(dvel_, params);
         dp_pf_ = dP_orf_;
         if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
             s = tanh(20*dvel_);
@@ -1391,7 +1389,7 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         Fd(Nvec) = Fd(Nvec) - F_story_;
         Fd(Mvec) = Fd(Mvec) + F_story_;
     end
-    function [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force(dvel, params)
+    function [F_orf, dP_orf, Q, P_orf_per, P_lam_per, P_kv_per] = calc_orifice_force(dvel, params)
         % Phase 6 (no p-states): smoother Cd(Re) with laminar + kv drop.
 
         % Saturated volumetric flow magnitude (stability)
@@ -1420,8 +1418,6 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         denom  = max(1, nd * n_orf);
         R_lam  = (128 * params.mu .* params.Lori ./ (pi * d_o.^4)) / denom;
         dP_lam = R_lam .* Q;
-        P_lam_per = dP_lam .* Q;
-        P_lam_per = max(P_lam_per, 0);
         dP_h   = dP_lam + dP_kv;
 
         % Cavitation soft-limit via softmin (magnitude)
@@ -1437,8 +1433,13 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         dP_orf = dP_orf_mag .* sgn;
         F_orf  = dP_orf .* params.Ap;
 
+        % Laminer ve kv bileşenlerini kavitatif limitlerle tutarlı şekilde ayır
+        dP_lam_eff = sign(Q) .* min(abs(dP_lam), dP_orf_mag);
+        P_lam_per  = abs(dP_lam_eff) .* abs(Q);
+        P_kv_per   = max(dP_orf_mag - abs(dP_lam_eff), 0) .* abs(Q);
+
         % Diagnostics (positive power)
-        P_orf_per = dP_orf_mag .* abs(Q);
+        P_orf_per = P_lam_per + P_kv_per;
     end
 end
 


### PR DESCRIPTION
## Summary
- return a separate kv power term from the orifice force helper so laminar and kv contributions can be tallied independently
- limit the laminar drop by the cavitation cap before forming dissipation metrics and accumulate totals from the separated components
- expose the new laminar/kv split in the time-series diagnostics for both the multi-DOF and SDOF damper models

## Testing
- not run (MATLAB/Octave interpreter is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c970e7eb048328a1deb42fd3e38a25