### PR TITLE
Derive cavitation flag from orifice limit

### DIFF
--- a/sdof.m
+++ b/sdof.m
@@ -618,7 +618,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     end
     params_orf = struct('Ap',Ap,'Qcap',Qcap_eff,'orf',orf_loc,'rho',rho,...
                         'Ao',Ao,'mu',mu_abs,'F_lin',F_lin,'Lori',Lori);
-    [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force_local(dvel, params_orf);
+    [F_orf, dP_orf, Q, P_orf_per, P_lam_per, P_kv_per, cav_mask_per] = calc_orifice_force_local(dvel, params_orf);
 
     qmag_loc = Qcap_eff * tanh( (Ap/Qcap_eff) * sqrt(dvel.^2 + orf.veps^2) );
     Re_loc   = (rho .* qmag_loc .* max(orf.d_o,1e-9)) ./ max(Ao*mu_abs,1e-9);
@@ -639,12 +639,10 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     F_p = k_sd*drift + (w_pf_vec .* dp_pf) * Ap;
 
     F_story = F_p;
-    % Split the laminar component from the total orifice power so the
-    % accumulator uses the true dissipation without double counting.
-    P_lam_share = min(P_lam_per, P_orf_per);
-    P_kv_per = max(P_orf_per - P_lam_share, 0);
-    P_orf_net_per = P_lam_share + P_kv_per;
-    P_sum = sum(P_orf_net_per .* multi, 2);
+    % Orifis gücünü laminer ve kv bileşenlerine ayır ve toplam gücü bunların
+    % toplamı olarak hesapla.
+    P_orf_net_per = P_lam_per + P_kv_per;
+    P_sum = sum((P_lam_per + P_kv_per) .* multi, 2);
     P_orf_tot = sum(P_orf_net_per .* multi, 2);
     P_struct_tot = sum(F_story .* dvel, 2);
     E_orf = cumtrapz(t, P_orf_tot);
@@ -678,7 +676,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     a_rel = ( -(M\(C*v.' + K*x.' + F.')).' - ag.*r.' );
 
     ts = struct('dvel', dvel, 'story_force', F_story, 'Q', Q, ...
-        'dP_orf', dP_orf, 'PF', F_p, 'cav_mask', dP_orf < 0, 'P_sum', P_sum, ...
+        'dP_orf', dP_orf, 'PF', F_p, 'cav_mask', cav_mask_per, 'P_sum', P_sum, ...
         'E_orf', E_orf, 'E_struct', E_struct, 'T_oil', T_o, 'mu', mu, ...
         'c_lam', c_lam, 'P_lam', P_lam_per, 'P_kv', P_kv_per, 'P_orf', P_orf_net_per);
 
@@ -688,7 +686,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
         F_lin_ = k_sd*drift_;
         params_loc = struct('Ap',Ap,'Qcap',Qcap,'orf',orf,'rho',rho,...
                         'Ao',Ao,'mu',mu_abs_loc,'F_lin',F_lin_,'Lori',Lori);
-        [~, dP_orf_, ~, ~, ~] = calc_orifice_force_local(dvel_, params_loc);
+        [~, dP_orf_, ~, ~, ~, ~, ~] = calc_orifice_force_local(dvel_, params_loc);
         dp_pf_ = dP_orf_;
         if isfield(cfg.on,'pf_resistive_only') && cfg.on.pf_resistive_only
             s = tanh(20*dvel_);
@@ -703,7 +701,7 @@ function [x,a_rel,ts] = mck_with_damper_local(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,
     end
 end
 
-function [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force_local(dvel, params)
+function [F_orf, dP_orf, Q, P_orf_per, P_lam_per, P_kv_per, cav_mask_per] = calc_orifice_force_local(dvel, params)
     qmag = params.Qcap * tanh( (params.Ap/params.Qcap) * sqrt(dvel.^2 + params.orf.veps^2) );
     sgn  = dvel ./ sqrt(dvel.^2 + params.orf.veps^2);
     Q    = qmag .* sgn;
@@ -733,12 +731,18 @@ function [F_orf, dP_orf, Q, P_orf_per, P_lam_per] = calc_orifice_force_local(dve
     if isfield(params,'orf') && isfield(params.orf,'softmin_eps') && isfinite(params.orf.softmin_eps)
         epsm = params.orf.softmin_eps;
     end
-    dP_orf_mag = softmin_local(abs(dP_h), dP_cav, epsm);
+    raw_mag    = abs(dP_h);
+    dP_orf_mag = softmin_local(raw_mag, dP_cav, epsm);
 
     dP_orf = dP_orf_mag .* sgn;
     F_orf  = dP_orf .* params.Ap;
 
-    P_orf_per = dP_orf_mag .* abs(Q);
-    P_lam_per = dP_lam .* Q;
-    P_lam_per = max(P_lam_per, 0);
+    dP_lam_eff = sign(Q) .* min(abs(dP_lam), dP_orf_mag);
+    P_lam_per  = abs(dP_lam_eff) .* abs(Q);
+    P_kv_per   = max(dP_orf_mag - abs(dP_lam_eff), 0) .* abs(Q);
+
+    P_orf_per = P_lam_per + P_kv_per;
+
+    tol = max(1e-3 .* max(dP_cav, 1), 1e-6);
+    cav_mask_per = raw_mag > (dP_orf_mag + tol);
 end


### PR DESCRIPTION
## Summary
- propagate a cavitation-activation mask from the orifice solver so time-series diagnostics no longer infer cavitation from the pressure drop sign
- compute the mask by comparing the raw laminar-plus-kv drop against the cavitation-limited magnitude inside both solver variants

## Testing
- not run (MATLAB/Octave interpreter is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68c970e7eb048328a1deb42fd3e38a25