### PR TITLE
Improve cavitation mask gating against softmin smoothing

### DIFF
--- a/viskoz.m
+++ b/viskoz.m
@@ -1418,8 +1418,8 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         denom  = max(1, nd * n_orf);
         R_lam  = (128 * params.mu .* params.Lori ./ (pi * d_o.^4)) / denom;
         dP_lam = R_lam .* Q;
-        dP_h   = dP_lam + dP_kv;
-        dP_h_mag = abs(dP_h);
+        dP_raw    = dP_lam + dP_kv;
+        dP_raw_mag = abs(dP_raw);
 
         % Cavitation soft-limit via softmin (magnitude)
         p_up     = params.orf.p_amb + abs(params.F_lin)./max(params.Ap,1e-12);
@@ -1428,9 +1428,12 @@ function [x,a_rel,ts] = mck_with_damper(t,ag,M,C,K, k_sd,c_lam0,Lori, orf,rho,Ap
         if isfield(params,'orf') && isfield(params.orf,'softmin_eps') && isfinite(params.orf.softmin_eps)
             epsm = params.orf.softmin_eps;
         end
-        dP_orf_mag = util_softmin(dP_h_mag, dP_cav, epsm);
-        tol = 1e-6 * max(1, dP_h_mag) + 1e-2 * epsm;
-        cav_mask_per = dP_h_mag > (dP_orf_mag + tol);
+        dP_orf_mag = util_softmin(dP_raw_mag, dP_cav, epsm);
+        % Sürtünme sınırlandırıcısının devreye girip girmediğini anlamak için
+        % sert kavitasyon limitini referans al.
+        dP_lim_mag = min(dP_raw_mag, dP_cav);
+        tol = max(1e-9, sqrt(eps) * max(1, dP_lim_mag));
+        cav_mask_per = dP_raw_mag > (dP_lim_mag + tol);
 
         % Force sign from velocity (no p-states)
         dP_orf = dP_orf_mag .* sgn;


### PR DESCRIPTION
## Summary
- derive the cavitation activation mask by comparing the raw orifice drop to the hard cavitation cap instead of the soft-min output
- apply the same limiter-aware mask construction in the single-degree-of-freedom helper so diagnostics stay consistent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9da5a176083288256fc7d68befe59