### PR TITLE
Clamp accumulator back pressure to upstream level

### DIFF
--- a/sdof.m
+++ b/sdof.m
@@ -949,6 +949,9 @@ function [F_orf, dP_total, Q, P_orf_per, Cd] = calc_orifice_force_local(dvel, pa
     w_sum = kappa_gas + kappa_lin + w_bleed + w_base;
     p_back = (kappa_gas .* p_gas + kappa_lin .* p_res_lin + w_bleed .* p_bleed + w_base .* p_min) ./ w_sum;
     p_back = max(p_back, p_min);
+    % Gaz/rezervuar kombinasyonu ortamın üstüne çıkabilir ancak piston tarafı
+    % basıncını aşamaz; aksi halde model ters akışı çözmek zorunda kalır.
+    p_back = min(p_back, p_up);
 
     dP_supply = max(p_up - p_back, 0);
     p_cav_floor = max(params.orf.p_cav_eff, 0);


### PR DESCRIPTION
## Summary
- prevent the blended reservoir pressure from exceeding the piston-side pressure when computing the orifice drop
- document that the clamp avoids having to model reverse flow while still allowing pressures above ambient

## Testing
- `octave -qf sdof.m` *(fails: `octave` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8b1f98b883288b3dd4e53ba3879e