### PR TITLE
Use constant vapor pressure approximation

### DIFF
--- a/sdof.m
+++ b/sdof.m
@@ -833,13 +833,9 @@ function mat = expand_to_matrix_local(val, nR, nC)
     end
 end
 function p_v = p_vap_Antoine_local(T_C, thermal, orf)
-    if nargin < 3 || isempty(orf), orf = struct(); end
-    A = getfield_default_local(thermal,'antoine_A',5.0);
-    B = getfield_default_local(thermal,'antoine_B',1700);
-    C = getfield_default_local(thermal,'antoine_C',-80);
-    T_C = double(T_C);
-    p_v = 10.^(A - B./(C + T_C));
-    p_v = min(max(p_v, 5), 5e2);
+    %#ok<INUSD>
+    p_v_const = getfield_default_local(thermal,'p_vap_const_Pa', 150);
+    p_v = max(1, p_v_const);
 end
 function params = default_params()
 


### PR DESCRIPTION
## Summary
- replace the Antoine-equation vapor pressure model with a constant-value approximation tied to `thermal.p_vap_const_Pa`
- ensure the vapor pressure floor stays above 1 Pa to avoid zero values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd443f8264832887a6b4244c533e6c