### PR TITLE
Update laminar damping coefficient to use R_lam formulation

### DIFF
--- a/sdof.m
+++ b/sdof.m
@@ -1129,7 +1129,10 @@ function params = recompute_damper_params_local(params)
     k_sd_simple = k_hyd + k_p;
     k_sd_adv    = nd * (k_hyd + k_p);
 
-    c_lam0 = 12 * params.mu_ref * params.Lori * Ap^2 / (params.orf.d_o^4);
+    % --- Laminer eşdeğer c: R_lam * A_p^2 ile TUTARLI ---
+    R_lam_single = (128 * params.mu_ref * params.Lori) / (pi * params.orf.d_o^4);
+    R_lam_total  = R_lam_single / max(params.n_orf,1);
+    c_lam0 = R_lam_total * ((pi * params.Dp^2 / 4)^2);
 
     params.Ap = Ap;
     params.Ao = Ao;


### PR DESCRIPTION
## Summary
- replace the laminar damping coefficient computation with the orifice-consistent R_lam formulation
- ensure the total laminar resistance accounts for the number of orifices and multiplies by A_p^2

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6a81662483289b10cd1a43e4ee20